### PR TITLE
don't use python 3.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
-          python-version: 3.12
+          python-version: 3.11
 
       - name: Make environment
         run: make install-ci

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Make environment
         run: make install-ci

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v5
       with:
-        python-version: "3.12"
+        python-version: "3.11"
 
     - name: Make environment
       run: make install-ci

--- a/.github/workflows/type-checking.yaml
+++ b/.github/workflows/type-checking.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Make environment
         run: make install-ci

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     rev: 7.1.1
     hooks:
       - id: flake8
-        language_version: python3.12
+        language_version: python3.11
   - repo: https://github.com/pycqa/isort
     rev: 6.0.0
     hooks:
@@ -44,4 +44,4 @@ repos:
         language: system
 
 default_language_version:
-  python: python3.12
+  python: python3.11


### PR DESCRIPTION
We're supporting 3.11 as a minimum version since this library needs to be used in sentry (since #13), this updates all our other 3.12 references to be 3.11.