### PR TITLE
unified config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ docker run --rm \
   --network "devservices" \
   sentry-kafka-management:local \
   get-topics \
-  -c /config/local-clusters.yml \
-  -t /config/local-topics.yml \
+  -c /config/local.yml \
   -n <cluster-name>
 ```

--- a/devservices/kafka-conf/local-clusters.yml
+++ b/devservices/kafka-conf/local-clusters.yml
@@ -1,7 +1,0 @@
-local:
-  brokers:
-    - kafka-kafka-1:9094
-  security_protocol: PLAINTEXT
-  sasl_mechanism: null
-  sasl_username: null
-  sasl_password: null

--- a/devservices/kafka-conf/local-topics.yml
+++ b/devservices/kafka-conf/local-topics.yml
@@ -1,8 +1,0 @@
-local:
-  test_topic:
-    partitions: 1
-    replication_factor: 1
-    placement:
-      zone: zone1
-    settings:
-      retention.ms: 86400000

--- a/devservices/kafka-conf/local.yml
+++ b/devservices/kafka-conf/local.yml
@@ -1,0 +1,15 @@
+- name: local
+  brokers:
+    - kafka-kafka-1:9094
+  security_protocol: PLAINTEXT
+  sasl_mechanism: null
+  sasl_username: null
+  sasl_password: null
+  topics:
+  - name: test_topic
+    partitions: 1
+    replication_factor: 1
+    placement:
+      zone: zone1
+    settings:
+      retention.ms: 86400000

--- a/sentry_kafka_management/common.py
+++ b/sentry_kafka_management/common.py
@@ -14,16 +14,9 @@ def kafka_script_parser(description: str | None, epilog: str | None) -> Argument
     )
     parser.add_argument(
         "-c",
-        "--cluster-config",
+        "--config",
         type=Path,
         required=True,
-        help="Path to the cluster YAML configuration file",
-    )
-    parser.add_argument(
-        "-t",
-        "--topic-config",
-        type=Path,
-        required=True,
-        help="Path to the topics' YAML configuration file",
+        help="Path to the YAML configuration file",
     )
     return parser

--- a/sentry_kafka_management/scripts/brokers.py
+++ b/sentry_kafka_management/scripts/brokers.py
@@ -19,9 +19,8 @@ List all broker configs in a cluster, including whether they were set dynamicall
         """,
         epilog="""
 Examples:
-  %(prog)s -c config.yml -t topic.yml
-  %(prog)s -c config.yml -t topic.yml -n my-cluster
-  %(prog)s --cluster-config config.yml --topic-config topic.yml --cluster production
+  %(prog)s -c config.yml -n my-cluster
+  %(prog)s --config config.yml --cluster production
         """,
     )
 
@@ -34,7 +33,7 @@ Examples:
 
     args = parser.parse_args(argv)
 
-    config = YamlKafkaConfig(args.cluster_config, args.topic_config)
+    config = YamlKafkaConfig(args.config)
     cluster_config = config.get_clusters()[args.cluster]
     client = get_admin_client(cluster_config)
     result = describe_broker_configs_action(client)

--- a/sentry_kafka_management/scripts/topics.py
+++ b/sentry_kafka_management/scripts/topics.py
@@ -16,9 +16,8 @@ def list_topics(argv: Sequence[str] | None = None) -> int:
         description="List Kafka topics using a single clusters configuration file",
         epilog="""
 Examples:
-  %(prog)s -c config.yml -t topic.yml
   %(prog)s -c config.yml -t topic.yml -n my-cluster
-  %(prog)s --cluster-config config.yml --topic-config topic.yml --cluster production
+  %(prog)s --config config.yml --cluster production
         """,
     )
 
@@ -31,7 +30,7 @@ Examples:
 
     args = parser.parse_args(argv)
 
-    config = YamlKafkaConfig(args.cluster_config, args.topic_config)
+    config = YamlKafkaConfig(args.config)
     cluster_config = config.get_clusters()[args.cluster]
     client = get_admin_client(cluster_config)
     result = list_topics_action(client)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,65 +6,54 @@ import pytest
 
 
 @pytest.fixture
-def temp_clusters_config() -> Generator[Path, None, None]:
-    """Create a temporary clusters configuration file with two clusters."""
-    clusters_config = {
-        "cluster1": {
+def temp_config() -> Generator[Path, None, None]:
+    """Create a temporary configuration file with two clusters."""
+    config = [
+        {
+            "name": "cluster1",
             "brokers": ["broker1:9092", "broker2:9092"],
             "security_protocol": "PLAINTEXT",
             "sasl_mechanism": None,
             "sasl_username": None,
-            "sasl_password": None
+            "sasl_password": None,
+            "topics": [
+                {
+                    "name": "topic1",
+                    "partitions": 3,
+                    "placement": {"rack": "rack1"},
+                    "replication_factor": 2,
+                    "settings": {"retention.ms": "86400000"}
+                },
+                {
+                    "name": "topic2",
+                    "partitions": 5,
+                    "placement": {"rack": "rack2"},
+                    "replication_factor": 3,
+                    "settings": {"cleanup.policy": "delete"}
+                }
+            ]
         },
-        "cluster2": {
+        {
+            "name": "cluster2",
             "brokers": ["broker3:9092", "broker4:9092"],
             "security_protocol": "SASL_SSL",
             "sasl_mechanism": "PLAIN",
             "sasl_username": "user1",
-            "sasl_password": "pass1"
+            "sasl_password": "pass1",
+            "topics": [
+                {
+                    "name": "topic3",
+                    "partitions": 2,
+                    "placement": {"zone": "zone1"},
+                    "replication_factor": 2,
+                    "settings": {"compression.type": "snappy"}
+                }
+            ]
         }
-    }
+    ]
 
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-        yaml.dump(clusters_config, f)
-        temp_path = Path(f.name)
-
-    yield temp_path
-
-    # Cleanup
-    temp_path.unlink()
-
-
-@pytest.fixture
-def temp_topics_config() -> Generator[Path, None, None]:
-    """Create a temporary topics configuration file with topics for two clusters."""
-    topics_config = {
-        "cluster1": {
-            "topic1": {
-                "partitions": 3,
-                "placement": {"rack": "rack1"},
-                "replication_factor": 2,
-                "settings": {"retention.ms": "86400000"}
-            },
-            "topic2": {
-                "partitions": 5,
-                "placement": {"rack": "rack2"},
-                "replication_factor": 3,
-                "settings": {"cleanup.policy": "delete"}
-            }
-        },
-        "cluster2": {
-            "topic3": {
-                "partitions": 2,
-                "placement": {"zone": "zone1"},
-                "replication_factor": 2,
-                "settings": {"compression.type": "snappy"}
-            }
-        }
-    }
-
-    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml', delete=False) as f:
-        yaml.dump(topics_config, f)
+        yaml.dump(config, f)
         temp_path = Path(f.name)
 
     yield temp_path

--- a/tests/scripts/test_brokers.py
+++ b/tests/scripts/test_brokers.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from sentry_kafka_management.scripts.brokers import describe_broker_configs
 
 
-def test_describe_broker_configs(temp_clusters_config: Path, temp_topics_config: Path) -> None:
+def test_describe_broker_configs(temp_config: Path) -> None:
     with patch(
         "sentry_kafka_management.scripts.brokers.describe_broker_configs_action",
     ) as mock_action, patch("builtins.print") as mock_print:
@@ -21,10 +21,8 @@ def test_describe_broker_configs(temp_clusters_config: Path, temp_topics_config:
         ]
         mock_action.return_value = mock_configs
         custom_argv = [
-            "--cluster-config",
-            str(temp_clusters_config),
-            "--topic-config",
-            str(temp_topics_config),
+            "--config",
+            str(temp_config),
             "--cluster",
             "cluster1"
         ]

--- a/tests/scripts/test_topics.py
+++ b/tests/scripts/test_topics.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 from sentry_kafka_management.scripts.topics import list_topics
 
 
-def test_list_topics(temp_clusters_config: Path, temp_topics_config: Path) -> None:
+def test_list_topics(temp_config: Path) -> None:
     with patch(
         "sentry_kafka_management.scripts.topics.list_topics_action",
     ) as mock_action, patch("builtins.print") as mock_print:
@@ -16,10 +16,8 @@ def test_list_topics(temp_clusters_config: Path, temp_topics_config: Path) -> No
         ]
         mock_action.return_value = mock_topics
         custom_argv = [
-            "--cluster-config",
-            str(temp_clusters_config),
-            "--topic-config",
-            str(temp_topics_config),
+            "--config",
+            str(temp_config),
             "--cluster",
             "cluster1"
         ]

--- a/tests/test_brokers.py
+++ b/tests/test_brokers.py
@@ -2,10 +2,10 @@ from sentry_kafka_management.brokers import YamlKafkaConfig
 from pathlib import Path
 
 
-def test_load_clusters_only(temp_clusters_config: Path, temp_topics_config: Path) -> None:
+def test_load_clusters_only(temp_config: Path) -> None:
     """Test loading configuration with only clusters defined."""
 
-    config = YamlKafkaConfig(temp_clusters_config, temp_topics_config)
+    config = YamlKafkaConfig(temp_config)
 
     # Test clusters loading
     clusters = config.get_clusters()
@@ -32,9 +32,9 @@ def test_load_clusters_only(temp_clusters_config: Path, temp_topics_config: Path
     assert cluster2["sasl_password"] == "pass1"
 
 
-def test_load_clusters_and_topics(temp_clusters_config: Path, temp_topics_config: Path) -> None:
+def test_load_clusters_and_topics(temp_config: Path) -> None:
 
-    config = YamlKafkaConfig(temp_clusters_config, temp_topics_config)
+    config = YamlKafkaConfig(temp_config)
 
     # Test clusters loading
     clusters = config.get_clusters()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,7 +6,7 @@ from sentry_kafka_management.cli import main as cli
 
 # TODO: we should turn this into a parameterized test case
 # since 90% of the test for each subcommand is the same
-def test_cli(temp_clusters_config: Path, temp_topics_config: Path) -> None:
+def test_cli(temp_config: Path) -> None:
     mock_list_topics = Mock()
     mock_describe_configs = Mock()
     mock_functions = {
@@ -19,18 +19,14 @@ def test_cli(temp_clusters_config: Path, temp_topics_config: Path) -> None:
     ):
         res = cli([
             "get-topics",
-            "--cluster-config",
-            str(temp_clusters_config),
-            "--topic-config",
-            str(temp_topics_config),
+            "--config",
+            str(temp_config),
             "--cluster",
             "cluster1"
         ])
         mock_list_topics.assert_called_once_with([
-            "--cluster-config",
-            str(temp_clusters_config),
-            "--topic-config",
-            str(temp_topics_config),
+            "--config",
+            str(temp_config),
             "--cluster",
             "cluster1"
         ])
@@ -38,18 +34,14 @@ def test_cli(temp_clusters_config: Path, temp_topics_config: Path) -> None:
 
         res = cli([
             "describe-broker-configs",
-            "--cluster-config",
-            str(temp_clusters_config),
-            "--topic-config",
-            str(temp_topics_config),
+            "--config",
+            str(temp_config),
             "--cluster",
             "cluster1"
         ])
         mock_describe_configs.assert_called_once_with([
-            "--cluster-config",
-            str(temp_clusters_config),
-            "--topic-config",
-            str(temp_topics_config),
+            "--config",
+            str(temp_config),
             "--cluster",
             "cluster1"
         ])


### PR DESCRIPTION
This PR:
- refactors our `cluster` and `topic` config files to be unified in a single config file
- changes the config file to have only static keys with dynamic values as YAML doesn't support dynamic keys at all (even with jinja)
  - i.e. instead of the cluster/topic names being keys, we use the `name:` key with the actual name as a value

The goal of this PR is to make the config file easier to auto-generate from the ops repo `shared_config`.