### PR TITLE
feat: add action for describing broker configs

### DIFF
--- a/sentry_kafka_management/actions/brokers.py
+++ b/sentry_kafka_management/actions/brokers.py
@@ -6,7 +6,7 @@ from confluent_kafka.admin import (  # type: ignore[import-untyped]
     ConfigSource,
 )
 
-KAFKA_TIMEOUT = 5
+from sentry_kafka_management.actions.conf import KAFKA_TIMEOUT
 
 
 def describe_broker_configs(

--- a/sentry_kafka_management/actions/conf.py
+++ b/sentry_kafka_management/actions/conf.py
@@ -1,0 +1,2 @@
+# Shared configuration globals used by actions
+KAFKA_TIMEOUT = 5

--- a/sentry_kafka_management/actions/topics.py
+++ b/sentry_kafka_management/actions/topics.py
@@ -1,4 +1,12 @@
-from confluent_kafka.admin import AdminClient  # type: ignore[import-untyped]
+from typing import Any, Mapping, Sequence
+
+from confluent_kafka.admin import (  # type: ignore[import-untyped]
+    AdminClient,
+    ConfigResource,
+    ConfigSource,
+)
+
+from sentry_kafka_management.actions.conf import KAFKA_TIMEOUT
 
 
 def list_topics(admin_client: AdminClient) -> list[str]:
@@ -8,3 +16,39 @@ def list_topics(admin_client: AdminClient) -> list[str]:
     # list_topics() returns TopicMetadata, we need to extract topic names
     topic_metadata = admin_client.list_topics()
     return list(topic_metadata.topics.keys())
+
+
+def describe_topic_configs(
+    admin_client: AdminClient,
+) -> Sequence[Mapping[str, Any]]:
+    """
+    Returns configuration for all topics in a cluster.
+    """
+    topic_resources = [
+        ConfigResource(ConfigResource.Type.TOPIC, f"{name}")
+        for name in admin_client.list_topics().topics
+    ]
+
+    all_configs = []
+
+    for topic_resource in topic_resources:
+        configs = {
+            k: v.result(KAFKA_TIMEOUT)
+            for (k, v) in admin_client.describe_configs([topic_resource]).items()
+        }[topic_resource]
+
+        for k, v in configs.items():
+            # the confluent library returns the raw int value of the enum instead of a
+            # ConfigSource object, so we have to convert it back into a ConfigSource
+            source_enum = ConfigSource(v.source) if isinstance(v.source, int) else v.source
+            config_item = {
+                "config": k,
+                "value": v.value,
+                "isDefault": v.is_default,
+                "isReadOnly": v.is_read_only,
+                "source": source_enum.name,
+                "topic": topic_resource.name,
+            }
+            all_configs.append(config_item)
+
+    return all_configs

--- a/tests/actions/test_brokers.py
+++ b/tests/actions/test_brokers.py
@@ -9,7 +9,7 @@ from sentry_kafka_management.actions.brokers import describe_broker_configs
 
 
 def test_describe_broker_configs() -> None:
-    """Test listing topics."""
+    """Test describing broker configs."""
     expected = [
         {
             "config": "num.network.threads",

--- a/tests/actions/test_topics.py
+++ b/tests/actions/test_topics.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
-from sentry_kafka_management.actions.topics import list_topics
+from confluent_kafka.admin import ConfigResource, ConfigSource  # type: ignore[import-untyped]
+from sentry_kafka_management.actions.topics import list_topics, describe_topic_configs
 
 
 def test_list_topics() -> None:
@@ -11,3 +12,40 @@ def test_list_topics() -> None:
     result = list_topics(mock_client)
     mock_client.list_topics.assert_called_once()
     assert result == ["test_topic"]
+
+
+def test_describe_topic_configs() -> None:
+    expected = [
+        {
+            "config": "segment.bytes",
+            "value": "300000",
+            "source": "DYNAMIC_TOPIC_CONFIG",
+            "isDefault": True,
+            "isReadOnly": False,
+            "topic": "test_topic",
+        },
+    ]
+
+    # admin client mock
+    mock_client = Mock()
+    mock_client.list_topics.return_value = Mock()
+    mock_client.list_topics.return_value.topics = {"test_topic": Mock()}
+    mock_client.describe_configs.return_value = Mock()
+
+    # mocking the future returned as the config value of describe_configs
+    conf_value_mock = Mock()
+    conf_value_mock.value = "300000"
+    conf_value_mock.is_default = True
+    conf_value_mock.is_read_only = False
+    conf_value_mock.source = ConfigSource.DYNAMIC_TOPIC_CONFIG
+
+    # mocking the config returned by describe_configs
+    conf_mock = Mock()
+    conf_mock.result.return_value = {"segment.bytes": conf_value_mock}
+    mock_client.describe_configs.return_value.items.return_value = [
+        (ConfigResource(ConfigResource.Type.TOPIC, "test_topic"), conf_mock)
+    ]
+
+    result = describe_topic_configs(mock_client)
+    mock_client.describe_configs.assert_called_once()
+    assert result == expected


### PR DESCRIPTION
This PR adds an action for describing topic configs.
I'll open another PR to use this action in `sentry-scripts` so we can get topic configs from a cluster in the script runner.