### PR TITLE
feat: Add the ability to skip specific configs

### DIFF
--- a/sentry_kafka_management/actions/local/manage_configs.py
+++ b/sentry_kafka_management/actions/local/manage_configs.py
@@ -23,6 +23,7 @@ def update_config_state(
     properties_file: Path,
     sasl_credentials_file: Path | None = None,
     dry_run: bool = False,
+    skip_config_names: frozenset[str] = frozenset(),
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """
     Gets the desired configs from reading emergency configs from record_dir,
@@ -44,6 +45,7 @@ def update_config_state(
         record_dir: Path to the directory containing emergency configs
         properties_file: Path to the server.properties file
         dry_run: Whether to dry run the config changes, only performs validation
+        skip_config_names: Broker config keys to leave unchanged (no apply or remove)
     """
     emergency_configs = read_record_dir(record_dir)
 
@@ -59,6 +61,8 @@ def update_config_state(
     configs_to_apply: dict[str, str] = {}
 
     for config_name, config_value in emergency_configs.items():
+        if config_name in skip_config_names:
+            continue
         # Skip if dynamic value already matches the emergency config
         if config_name in kafka_configs:
             active_config = kafka_configs[config_name]
@@ -73,6 +77,8 @@ def update_config_state(
         configs_to_apply[config_name] = config_value
 
     for config_name, desired_value in properties_configs.items():
+        if config_name in skip_config_names:
+            continue
         if config_name in emergency_configs:
             continue
 
@@ -101,6 +107,8 @@ def update_config_state(
     configs_to_remove: list[str] = []
 
     for config_name, active_config in kafka_configs.items():
+        if config_name in skip_config_names:
+            continue
         if active_config.dynamic_value is None:
             continue
 

--- a/sentry_kafka_management/scripts/local/manage_configs.py
+++ b/sentry_kafka_management/scripts/local/manage_configs.py
@@ -57,6 +57,11 @@ from sentry_kafka_management.scripts.config_helpers import get_cluster_config
     is_flag=True,
     help="Mutes some unnecessary output by the script",
 )
+@click.option(
+    "--skip-configs",
+    default=None,
+    help="Comma-separated broker config names to skip (no apply or remove changes)",
+)
 def update_config_state(
     config: Path,
     cluster: str,
@@ -65,6 +70,7 @@ def update_config_state(
     sasl_credentials_file: Path | None = None,
     dry_run: bool = False,
     quiet: bool = False,
+    skip_configs: str | None = None,
 ) -> None:
     """
     Updates the config state of the current broker by looking at emergency configs,
@@ -87,12 +93,17 @@ def update_config_state(
     cluster_config = get_cluster_config(config, cluster)
     client = get_admin_client(cluster_config)
 
+    skip_config_names = frozenset(
+        name.strip() for name in (skip_configs or "").split(",") if name.strip()
+    )
+
     success, error = update_config_state_action(
         client,
         record_dir,
         properties_file,
         sasl_credentials_file=sasl_credentials_file,
         dry_run=dry_run,
+        skip_config_names=skip_config_names,
     )
 
     if success:

--- a/tests/actions/local/test_manage_configs.py
+++ b/tests/actions/local/test_manage_configs.py
@@ -84,6 +84,49 @@ def test_update_config_state_emergency_priority(
 @patch("sentry_kafka_management.actions.local.manage_configs.remove_dynamic_configs")
 @patch("sentry_kafka_management.actions.local.manage_configs.apply_configs")
 @patch("sentry_kafka_management.actions.local.manage_configs.get_active_broker_configs")
+def test_update_config_state_skips_named_configs(
+    mock_get_configs: MagicMock,
+    mock_apply_configs: MagicMock,
+    mock_remove_configs: MagicMock,
+    mock_admin_client: MagicMock,
+    temp_record_dir: Path,
+    temp_properties_file: Path,
+) -> None:
+    """Skipped config names are not applied or removed."""
+    (temp_record_dir / "num.network.threads").write_text("1000")
+
+    temp_properties_file.write_text("broker.id=1001\n" "num.network.threads=5\n")
+
+    mock_get_configs.return_value = [
+        broker_id_config(),
+        Config(
+            config_name="num.network.threads",
+            is_sensitive=False,
+            active_value="3",
+            dynamic_value=None,
+            dynamic_default_value=None,
+            static_value=None,
+            default_value="3",
+        ),
+    ]
+
+    success, errors = update_config_state(
+        mock_admin_client,
+        temp_record_dir,
+        temp_properties_file,
+        dry_run=True,
+        skip_config_names=frozenset({"num.network.threads"}),
+    )
+
+    assert success == []
+    assert errors == []
+    mock_apply_configs.assert_not_called()
+    mock_remove_configs.assert_not_called()
+
+
+@patch("sentry_kafka_management.actions.local.manage_configs.remove_dynamic_configs")
+@patch("sentry_kafka_management.actions.local.manage_configs.apply_configs")
+@patch("sentry_kafka_management.actions.local.manage_configs.get_active_broker_configs")
 def test_update_config_state_apply_from_properties(
     mock_get_configs: MagicMock,
     mock_apply_configs: MagicMock,


### PR DESCRIPTION
When updating configurations, add the option to skip specific config values. This can be used later
to skip throttling configs in the cronjob to avoid conflicting with rebalancing.
