### PR TITLE
feat(consumer-latency): optimize batching and use multithreading

### DIFF
--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -63,7 +63,15 @@ class TopicConsumerLatency:
 @dataclass
 class ConsumerLatencyResult:
     scans: list[TopicConsumerLatency]
-    errors: list[Exception] | None = None
+    errors: list[Exception]
+
+    def __init__(
+        self,
+        scans: list[TopicConsumerLatency],
+        errors: list[Exception] | None = None,
+    ) -> None:
+        self.scans = scans
+        self.errors = errors or []
 
 
 class ConsumerGroupListingError(Exception):
@@ -74,7 +82,7 @@ class ConsumerGroupListingError(Exception):
     def __init__(
         self,
         errors: list[KafkaException],
-        valid: list[ConsumerGroupListing] | None = None,
+        valid: list[ConsumerGroupListing],
     ) -> None:
         formatted = "; ".join(str(error) for error in errors)
         super().__init__(f"Failed to list consumer groups ({len(errors)} error(s)): {formatted}")
@@ -366,7 +374,7 @@ def get_cluster_latency(
 
     logger.info(f"Time taken to scan cluster {cluster_name}: {time.monotonic() - t0:.3f}s")
 
-    return ConsumerLatencyResult(scans=scans, errors=errors or None)
+    return ConsumerLatencyResult(scans=scans, errors=errors)
 
 
 def record_consumer_group_latency(
@@ -393,4 +401,4 @@ def record_consumer_group_latency(
         if result.errors:
             errors.extend(result.errors)
 
-    return ConsumerLatencyResult(scans=scans, errors=errors or None)
+    return ConsumerLatencyResult(scans=scans, errors=errors)

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -253,9 +253,11 @@ def get_partition_latency(
 
 
 def get_consumer_group_latency(
+    admin: AdminClient,
     consumer_config: Mapping[str, object],
     cluster_name: str,
-    group_scans: list[PartitionScan],
+    group_id: str,
+    retentions_by_topic: Mapping[str, int],
     timeout: int,
 ) -> ConsumerLatencyResult:
     """
@@ -263,6 +265,26 @@ def get_consumer_group_latency(
     """
     scans: list[TopicConsumerLatency] = []
     errors: list[Exception] = []
+
+    committed = get_committed_offsets(admin, [group_id])[group_id]
+    if isinstance(committed, Exception):
+        errors.append(committed)
+        return ConsumerLatencyResult(scans=scans, errors=errors)
+
+    group_scans = [
+        PartitionScan(
+            group_id=group_id,
+            topic=tp.topic,
+            partition=tp.partition,
+            committed_offset=int(tp.offset),
+            retention_ms=retentions_by_topic[tp.topic],
+        )
+        for tp in committed
+        if tp.topic in retentions_by_topic
+    ]
+
+    if not group_scans:
+        return ConsumerLatencyResult(scans=scans, errors=errors)
 
     consumer = Consumer(dict(consumer_config))
     try:
@@ -337,27 +359,8 @@ def get_cluster_latency(
             group_ids = [listing.group_id for listing in e.valid]
 
         scan_group_ids = [g for g in group_ids if g != consumer_group_id]
-        offsets_by_group = get_committed_offsets(admin, scan_group_ids)
 
-        scans_by_group: dict[str, list[PartitionScan]] = {}
-        for group_id, committed_or_exc in offsets_by_group.items():
-            if isinstance(committed_or_exc, Exception):
-                errors.append(committed_or_exc)
-                continue
-            for tp in committed_or_exc:
-                if tp.topic not in retentions_by_topic:
-                    continue
-                scans_by_group.setdefault(group_id, []).append(
-                    PartitionScan(
-                        group_id=group_id,
-                        topic=tp.topic,
-                        partition=tp.partition,
-                        committed_offset=int(tp.offset),
-                        retention_ms=retentions_by_topic[tp.topic],
-                    )
-                )
-
-        if scans_by_group:
+        if scan_group_ids:
             with ThreadPoolExecutor(
                 max_workers=max_workers,
                 thread_name_prefix=f"latency-{cluster_name}",
@@ -365,12 +368,14 @@ def get_cluster_latency(
                 futures = [
                     executor.submit(
                         get_consumer_group_latency,
+                        admin,
                         consumer_config,
                         cluster_name,
-                        group_scans,
+                        group_id,
+                        retentions_by_topic,
                         timeout,
                     )
-                    for group_scans in scans_by_group.values()
+                    for group_id in scan_group_ids
                 ]
                 for future in as_completed(futures):
                     try:

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -309,7 +309,6 @@ def get_cluster_latency(
             worker_count = min(len(work), max_workers)
 
             consumers: list[Consumer] = []
-            consumers_lock = threading.Lock()
             consumer_local = threading.local()
 
             def get_consumer() -> Consumer:
@@ -317,8 +316,7 @@ def get_cluster_latency(
                 if consumer is None:
                     consumer = Consumer(dict(consumer_config))
                     consumer_local.consumer = consumer
-                    with consumers_lock:
-                        consumers.append(consumer)
+                    consumers.append(consumer)
                 return consumer
 
             def scan(item: PartitionScan) -> TopicConsumerLatency:

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -30,6 +30,8 @@ from sentry_kafka_management.connectors.kafka_config import build_broker_config
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_MAX_WORKERS = 128
+
 RETRYABLE_ERRORS = frozenset(
     {
         KafkaError.REQUEST_TIMED_OUT,
@@ -248,6 +250,7 @@ def get_cluster_latency(
     config: ClusterConfig,
     topics: Mapping[str, TopicConfig],
     timeout: int,
+    max_workers: int = DEFAULT_MAX_WORKERS,
 ) -> ConsumerLatencyResult:
     consumer_group_id = f"consumer-latency-group-{cluster_name}"
     scans: list[TopicConsumerLatency] = []
@@ -303,7 +306,7 @@ def get_cluster_latency(
                 )
 
         if work:
-            worker_count = min(len(work), 128)
+            worker_count = min(len(work), max_workers)
 
             consumers: list[Consumer] = []
             consumers_lock = threading.Lock()
@@ -372,6 +375,7 @@ def record_consumer_group_latency(
     config: YamlKafkaConfig,
     metrics: MetricsBackend,
     timeout: int = 10,
+    max_workers: int = DEFAULT_MAX_WORKERS,
 ) -> ConsumerLatencyResult:
     scans: list[TopicConsumerLatency] = []
     errors: list[Exception] = []
@@ -380,7 +384,7 @@ def record_consumer_group_latency(
     for cluster_name, cluster_config in clusters.items():
         try:
             topics = config.get_topics_config(cluster_name)
-            result = get_cluster_latency(cluster_name, cluster_config, topics, timeout)
+            result = get_cluster_latency(cluster_name, cluster_config, topics, timeout, max_workers)
         except Exception as e:
             errors.append(e)
             continue

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Mapping
 
@@ -36,6 +37,15 @@ RETRYABLE_ERRORS = frozenset(
         KafkaError.COORDINATOR_LOAD_IN_PROGRESS,
     }
 )
+
+
+@dataclass
+class _PartitionScan:
+    group_id: str
+    topic: str
+    partition: int
+    committed_offset: int
+    retention_ms: int
 
 
 @dataclass
@@ -84,20 +94,26 @@ def list_consumer_group_ids(admin: AdminClient) -> list[str]:
     return group_ids
 
 
-def get_committed_offsets(admin: AdminClient, group_id: str) -> list[TopicPartition]:
-    """Get the committed offsets for a consumer group."""
-    result: ConsumerGroupTopicPartitions = admin.list_consumer_group_offsets(
-        [ConsumerGroupTopicPartitions(group_id)]
-    )[group_id].result()
-
-    committed: list[TopicPartition] = []
-
-    for partition in result.topic_partitions:
-        if partition.error is not None:
-            raise KafkaException(partition.error)
-        committed.append(partition)
-
-    return committed
+def get_committed_offsets(
+    admin: AdminClient, group_ids: list[str]
+) -> dict[str, list[TopicPartition] | Exception]:
+    """Get committed offsets for one or more consumer groups."""
+    offset_futures = admin.list_consumer_group_offsets(
+        [ConsumerGroupTopicPartitions(group_id) for group_id in group_ids]
+    )
+    results: dict[str, list[TopicPartition] | Exception] = {}
+    for group_id in group_ids:
+        try:
+            cgtp: ConsumerGroupTopicPartitions = offset_futures[group_id].result()
+            committed: list[TopicPartition] = []
+            for partition in cgtp.topic_partitions:
+                if partition.error is not None:
+                    raise KafkaException(partition.error)
+                committed.append(partition)
+            results[group_id] = committed
+        except Exception as e:
+            results[group_id] = e
+    return results
 
 
 def read_timestamp_ms(
@@ -227,9 +243,9 @@ def get_cluster_latency(
     consumer_group_id = f"consumer-latency-group-{cluster_name}"
     scans: list[TopicConsumerLatency] = []
     errors: list[Exception] = []
-    consumer: Consumer | None = None
 
     retentions_by_topic: dict[str, int] = {}
+    max_partitions = 1
 
     for topic_name, topic_config in topics.items():
         retention_ms = topic_config["settings"].get("retention.ms")
@@ -237,16 +253,16 @@ def get_cluster_latency(
             retentions_by_topic[topic_name] = 604800000
         else:
             retentions_by_topic[topic_name] = int(retention_ms)
+        max_partitions = max(max_partitions, topic_config["partitions"])
+
+    consumer_config = {
+        "enable.auto.commit": False,
+        "group.id": consumer_group_id,
+        **build_broker_config(config),
+    }
 
     try:
         admin = get_admin_client(config)
-        consumer = Consumer(
-            {
-                "enable.auto.commit": False,
-                "group.id": consumer_group_id,
-                **build_broker_config(config),
-            }
-        )
 
         try:
             group_ids = list_consumer_group_ids(admin)
@@ -254,48 +270,63 @@ def get_cluster_latency(
             errors.extend(e.errors)
             group_ids = [listing.group_id for listing in e.valid]
 
-        for group_id in group_ids:
-            if group_id == consumer_group_id:
-                continue
+        scan_group_ids = [g for g in group_ids if g != consumer_group_id]
+        offsets_by_group = get_committed_offsets(admin, scan_group_ids)
 
-            try:
-                committed_offsets = get_committed_offsets(admin, group_id)
-            except Exception as e:
-                errors.append(e)
+        work: list[_PartitionScan] = []
+        for group_id, committed_or_exc in offsets_by_group.items():
+            if isinstance(committed_or_exc, Exception):
+                errors.append(committed_or_exc)
                 continue
-
-            for tp in committed_offsets:
+            for tp in committed_or_exc:
                 if tp.topic not in retentions_by_topic:
                     continue
+                work.append(
+                    _PartitionScan(
+                        group_id=group_id,
+                        topic=tp.topic,
+                        partition=tp.partition,
+                        committed_offset=int(tp.offset),
+                        retention_ms=retentions_by_topic[tp.topic],
+                    )
+                )
 
-                retention_ms = retentions_by_topic[tp.topic]
+        if work:
+            worker_count = min(max_partitions, len(work))
+
+            def scan(item: _PartitionScan) -> TopicConsumerLatency:
+                consumer = Consumer(dict(consumer_config))
                 try:
                     latency_ms = get_partition_latency(
                         consumer,
-                        tp.topic,
-                        tp.partition,
-                        int(tp.offset),
-                        retention_ms,
+                        item.topic,
+                        item.partition,
+                        item.committed_offset,
+                        item.retention_ms,
                         timeout,
                     )
-                except Exception as e:
-                    errors.append(e)
-                    continue
-
-                scans.append(
-                    TopicConsumerLatency(
-                        cluster_name=cluster_name,
-                        group_id=group_id,
-                        topic_name=tp.topic,
-                        latency_ms=latency_ms,
-                        partition=tp.partition,
-                    )
+                finally:
+                    consumer.close()
+                return TopicConsumerLatency(
+                    cluster_name=cluster_name,
+                    group_id=item.group_id,
+                    topic_name=item.topic,
+                    latency_ms=latency_ms,
+                    partition=item.partition,
                 )
+
+            with ThreadPoolExecutor(
+                max_workers=worker_count,
+                thread_name_prefix=f"latency-{cluster_name}",
+            ) as executor:
+                futures = [executor.submit(scan, item) for item in work]
+                for future in as_completed(futures):
+                    try:
+                        scans.append(future.result())
+                    except Exception as e:
+                        errors.append(e)
     except Exception as e:
         errors.append(e)
-    finally:
-        if consumer is not None:
-            consumer.close()
 
     return ConsumerLatencyResult(scans=scans, errors=errors or None)
 
@@ -307,15 +338,36 @@ def record_consumer_group_latency(
 ) -> ConsumerLatencyResult:
     scans: list[TopicConsumerLatency] = []
     errors: list[Exception] = []
+    clusters = config.get_clusters()
 
-    for cluster_name, cluster_config in config.get_clusters().items():
+    def run_cluster(cluster_name: str, cluster_config: ClusterConfig) -> ConsumerLatencyResult:
         topics = config.get_topics_config(cluster_name)
-        result = get_cluster_latency(cluster_name, cluster_config, topics, timeout)
+        return get_cluster_latency(cluster_name, cluster_config, topics, timeout)
 
+    results: dict[str, ConsumerLatencyResult] = {}
+
+    if clusters:
+        with ThreadPoolExecutor(
+            max_workers=len(clusters), thread_name_prefix="latency-cluster"
+        ) as executor:
+            futures = {
+                executor.submit(run_cluster, name, cluster_config): name
+                for name, cluster_config in clusters.items()
+            }
+            for future in as_completed(futures):
+                cluster_name = futures[future]
+                try:
+                    results[cluster_name] = future.result()
+                except Exception as e:
+                    errors.append(e)
+
+    for cluster_name in clusters:
+        result = results.get(cluster_name)
+        if result is None:
+            continue
         for scan in result.scans:
             emit_topic_consumer_latency(metrics, scan)
             scans.append(scan)
-
         if result.errors:
             errors.extend(result.errors)
 

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -43,7 +43,7 @@ RETRYABLE_ERRORS = frozenset(
 
 
 @dataclass
-class _PartitionScan:
+class PartitionScan:
     group_id: str
     topic: str
     partition: int
@@ -287,7 +287,7 @@ def get_cluster_latency(
         scan_group_ids = [g for g in group_ids if g != consumer_group_id]
         offsets_by_group = get_committed_offsets(admin, scan_group_ids)
 
-        work: list[_PartitionScan] = []
+        work: list[PartitionScan] = []
         for group_id, committed_or_exc in offsets_by_group.items():
             if isinstance(committed_or_exc, Exception):
                 errors.append(committed_or_exc)
@@ -296,7 +296,7 @@ def get_cluster_latency(
                 if tp.topic not in retentions_by_topic:
                     continue
                 work.append(
-                    _PartitionScan(
+                    PartitionScan(
                         group_id=group_id,
                         topic=tp.topic,
                         partition=tp.partition,
@@ -321,7 +321,7 @@ def get_cluster_latency(
                         consumers.append(consumer)
                 return consumer
 
-            def scan(item: _PartitionScan) -> TopicConsumerLatency:
+            def scan(item: PartitionScan) -> TopicConsumerLatency:
                 latency_ms = get_partition_latency(
                     get_consumer(),
                     item.topic,

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -253,6 +252,51 @@ def get_partition_latency(
     return latency_ms
 
 
+def get_consumer_group_latency(
+    consumer_config: Mapping[str, object],
+    cluster_name: str,
+    group_scans: list[PartitionScan],
+    timeout: int,
+) -> ConsumerLatencyResult:
+    """
+    Scan every partition for a single consumer group on one dedicated consumer.
+    """
+    scans: list[TopicConsumerLatency] = []
+    errors: list[Exception] = []
+
+    consumer = Consumer(dict(consumer_config))
+    try:
+        for item in group_scans:
+            try:
+                latency_ms = get_partition_latency(
+                    consumer,
+                    item.topic,
+                    item.partition,
+                    item.committed_offset,
+                    item.retention_ms,
+                    timeout,
+                )
+            except Exception as e:
+                errors.append(e)
+                continue
+            scans.append(
+                TopicConsumerLatency(
+                    cluster_name=cluster_name,
+                    group_id=item.group_id,
+                    topic_name=item.topic,
+                    latency_ms=latency_ms,
+                    partition=item.partition,
+                )
+            )
+    finally:
+        try:
+            consumer.close()
+        except Exception as e:
+            errors.append(e)
+
+    return ConsumerLatencyResult(scans=scans, errors=errors)
+
+
 def get_cluster_latency(
     cluster_name: str,
     config: ClusterConfig,
@@ -295,7 +339,7 @@ def get_cluster_latency(
         scan_group_ids = [g for g in group_ids if g != consumer_group_id]
         offsets_by_group = get_committed_offsets(admin, scan_group_ids)
 
-        work: list[PartitionScan] = []
+        scans_by_group: dict[str, list[PartitionScan]] = {}
         for group_id, committed_or_exc in offsets_by_group.items():
             if isinstance(committed_or_exc, Exception):
                 errors.append(committed_or_exc)
@@ -303,7 +347,7 @@ def get_cluster_latency(
             for tp in committed_or_exc:
                 if tp.topic not in retentions_by_topic:
                     continue
-                work.append(
+                scans_by_group.setdefault(group_id, []).append(
                     PartitionScan(
                         group_id=group_id,
                         topic=tp.topic,
@@ -313,62 +357,28 @@ def get_cluster_latency(
                     )
                 )
 
-        if work:
-            worker_count = min(len(work), max_workers)
-
-            consumers: list[Consumer] = []
-            consumer_local = threading.local()
-
-            def get_consumer() -> Consumer:
-                consumer = getattr(consumer_local, "consumer", None)
-                if consumer is None:
-                    consumer = Consumer(dict(consumer_config))
-                    consumer_local.consumer = consumer
-                    consumers.append(consumer)
-                return consumer
-
-            def scan(item: PartitionScan) -> TopicConsumerLatency:
-                latency_ms = get_partition_latency(
-                    get_consumer(),
-                    item.topic,
-                    item.partition,
-                    item.committed_offset,
-                    item.retention_ms,
-                    timeout,
-                )
-                return TopicConsumerLatency(
-                    cluster_name=cluster_name,
-                    group_id=item.group_id,
-                    topic_name=item.topic,
-                    latency_ms=latency_ms,
-                    partition=item.partition,
-                )
-
-            try:
-                with ThreadPoolExecutor(
-                    max_workers=worker_count,
-                    thread_name_prefix=f"latency-{cluster_name}",
-                ) as executor:
-                    futures = [executor.submit(scan, item) for item in work]
-                    for future in as_completed(futures):
-                        try:
-                            scans.append(future.result())
-                        except Exception as e:
-                            errors.append(e)
-            finally:
-                if consumers:
-                    with ThreadPoolExecutor(
-                        max_workers=len(consumers),
-                        thread_name_prefix=f"clr-close-{cluster_name}",
-                    ) as close_executor:
-                        close_futures = [
-                            close_executor.submit(consumer.close) for consumer in consumers
-                        ]
-                        for close_future in as_completed(close_futures):
-                            try:
-                                close_future.result()
-                            except Exception as e:
-                                errors.append(e)
+        if scans_by_group:
+            with ThreadPoolExecutor(
+                max_workers=max_workers,
+                thread_name_prefix=f"latency-{cluster_name}",
+            ) as executor:
+                futures = [
+                    executor.submit(
+                        get_consumer_group_latency,
+                        consumer_config,
+                        cluster_name,
+                        group_scans,
+                        timeout,
+                    )
+                    for group_scans in scans_by_group.values()
+                ]
+                for future in as_completed(futures):
+                    try:
+                        group_result = future.result()
+                        scans.extend(group_result.scans)
+                        errors.extend(group_result.errors)
+                    except Exception as e:
+                        errors.append(e)
     except Exception as e:
         errors.append(e)
 

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -347,18 +347,19 @@ def get_cluster_latency(
                         except Exception as e:
                             errors.append(e)
             finally:
-                with ThreadPoolExecutor(
-                    max_workers=len(consumers),
-                    thread_name_prefix=f"clr-close-{cluster_name}",
-                ) as close_executor:
-                    close_futures = [
-                        close_executor.submit(consumer.close) for consumer in consumers
-                    ]
-                    for close_future in as_completed(close_futures):
-                        try:
-                            close_future.result()
-                        except Exception as e:
-                            errors.append(e)
+                if consumers:
+                    with ThreadPoolExecutor(
+                        max_workers=len(consumers),
+                        thread_name_prefix=f"clr-close-{cluster_name}",
+                    ) as close_executor:
+                        close_futures = [
+                            close_executor.submit(consumer.close) for consumer in consumers
+                        ]
+                        for close_future in as_completed(close_futures):
+                            try:
+                                close_future.result()
+                            except Exception as e:
+                                errors.append(e)
     except Exception as e:
         errors.append(e)
 

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -256,6 +256,8 @@ def get_cluster_latency(
         max_partitions = max(max_partitions, topic_config["partitions"])
 
     consumer_config = {
+        "fetch.max.bytes": 1,
+        "max.partition.fetch.bytes": 1,
         "enable.auto.commit": False,
         "group.id": consumer_group_id,
         **build_broker_config(config),

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -377,31 +377,14 @@ def record_consumer_group_latency(
     errors: list[Exception] = []
     clusters = config.get_clusters()
 
-    def run_cluster(cluster_name: str, cluster_config: ClusterConfig) -> ConsumerLatencyResult:
-        topics = config.get_topics_config(cluster_name)
-        return get_cluster_latency(cluster_name, cluster_config, topics, timeout)
-
-    results: dict[str, ConsumerLatencyResult] = {}
-
-    if clusters:
-        with ThreadPoolExecutor(
-            max_workers=len(clusters), thread_name_prefix="latency-cluster"
-        ) as executor:
-            futures = {
-                executor.submit(run_cluster, name, cluster_config): name
-                for name, cluster_config in clusters.items()
-            }
-            for future in as_completed(futures):
-                cluster_name = futures[future]
-                try:
-                    results[cluster_name] = future.result()
-                except Exception as e:
-                    errors.append(e)
-
-    for cluster_name in clusters:
-        result = results.get(cluster_name)
-        if result is None:
+    for cluster_name, cluster_config in clusters.items():
+        try:
+            topics = config.get_topics_config(cluster_name)
+            result = get_cluster_latency(cluster_name, cluster_config, topics, timeout)
+        except Exception as e:
+            errors.append(e)
             continue
+
         for scan in result.scans:
             emit_topic_consumer_latency(metrics, scan)
             scans.append(scan)

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -98,13 +99,21 @@ def get_committed_offsets(
     admin: AdminClient, group_ids: list[str]
 ) -> dict[str, list[TopicPartition] | Exception]:
     """Get committed offsets for one or more consumer groups."""
-    offset_futures = admin.list_consumer_group_offsets(
-        [ConsumerGroupTopicPartitions(group_id) for group_id in group_ids]
-    )
     results: dict[str, list[TopicPartition] | Exception] = {}
+
+    futures = {}
+
     for group_id in group_ids:
         try:
-            cgtp: ConsumerGroupTopicPartitions = offset_futures[group_id].result()
+            partitions = [ConsumerGroupTopicPartitions(group_id)]
+            offsets = admin.list_consumer_group_offsets(partitions)
+            futures[group_id] = offsets[group_id]
+        except Exception as e:
+            results[group_id] = e
+
+    for group_id, future in futures.items():
+        try:
+            cgtp: ConsumerGroupTopicPartitions = future.result()
             committed: list[TopicPartition] = []
             for partition in cgtp.topic_partitions:
                 if partition.error is not None:
@@ -245,7 +254,6 @@ def get_cluster_latency(
     errors: list[Exception] = []
 
     retentions_by_topic: dict[str, int] = {}
-    max_partitions = 1
 
     for topic_name, topic_config in topics.items():
         retention_ms = topic_config["settings"].get("retention.ms")
@@ -253,15 +261,16 @@ def get_cluster_latency(
             retentions_by_topic[topic_name] = 604800000
         else:
             retentions_by_topic[topic_name] = int(retention_ms)
-        max_partitions = max(max_partitions, topic_config["partitions"])
 
     consumer_config = {
-        "fetch.max.bytes": 1,
-        "max.partition.fetch.bytes": 1,
+        "queued.min.messages": 1,
+        "queued.max.messages.kbytes": 1,
         "enable.auto.commit": False,
         "group.id": consumer_group_id,
         **build_broker_config(config),
     }
+
+    t0 = time.monotonic()
 
     try:
         admin = get_admin_client(config)
@@ -294,21 +303,30 @@ def get_cluster_latency(
                 )
 
         if work:
-            worker_count = min(max_partitions, len(work))
+            worker_count = min(len(work), 128)
+
+            consumers: list[Consumer] = []
+            consumers_lock = threading.Lock()
+            consumer_local = threading.local()
+
+            def get_consumer() -> Consumer:
+                consumer = getattr(consumer_local, "consumer", None)
+                if consumer is None:
+                    consumer = Consumer(dict(consumer_config))
+                    consumer_local.consumer = consumer
+                    with consumers_lock:
+                        consumers.append(consumer)
+                return consumer
 
             def scan(item: _PartitionScan) -> TopicConsumerLatency:
-                consumer = Consumer(dict(consumer_config))
-                try:
-                    latency_ms = get_partition_latency(
-                        consumer,
-                        item.topic,
-                        item.partition,
-                        item.committed_offset,
-                        item.retention_ms,
-                        timeout,
-                    )
-                finally:
-                    consumer.close()
+                latency_ms = get_partition_latency(
+                    get_consumer(),
+                    item.topic,
+                    item.partition,
+                    item.committed_offset,
+                    item.retention_ms,
+                    timeout,
+                )
                 return TopicConsumerLatency(
                     cluster_name=cluster_name,
                     group_id=item.group_id,
@@ -317,18 +335,34 @@ def get_cluster_latency(
                     partition=item.partition,
                 )
 
-            with ThreadPoolExecutor(
-                max_workers=worker_count,
-                thread_name_prefix=f"latency-{cluster_name}",
-            ) as executor:
-                futures = [executor.submit(scan, item) for item in work]
-                for future in as_completed(futures):
-                    try:
-                        scans.append(future.result())
-                    except Exception as e:
-                        errors.append(e)
+            try:
+                with ThreadPoolExecutor(
+                    max_workers=worker_count,
+                    thread_name_prefix=f"latency-{cluster_name}",
+                ) as executor:
+                    futures = [executor.submit(scan, item) for item in work]
+                    for future in as_completed(futures):
+                        try:
+                            scans.append(future.result())
+                        except Exception as e:
+                            errors.append(e)
+            finally:
+                with ThreadPoolExecutor(
+                    max_workers=len(consumers),
+                    thread_name_prefix=f"clr-close-{cluster_name}",
+                ) as close_executor:
+                    close_futures = [
+                        close_executor.submit(consumer.close) for consumer in consumers
+                    ]
+                    for close_future in as_completed(close_futures):
+                        try:
+                            close_future.result()
+                        except Exception as e:
+                            errors.append(e)
     except Exception as e:
         errors.append(e)
+
+    logger.info(f"Time taken to scan cluster {cluster_name}: {time.monotonic() - t0:.3f}s")
 
     return ConsumerLatencyResult(scans=scans, errors=errors or None)
 

--- a/sentry_kafka_management/scripts/latency/consumer_latency.py
+++ b/sentry_kafka_management/scripts/latency/consumer_latency.py
@@ -7,6 +7,9 @@ from pathlib import Path
 import click
 
 from sentry_kafka_management.actions.latency.consumer_latency import (
+    DEFAULT_MAX_WORKERS,
+)
+from sentry_kafka_management.actions.latency.consumer_latency import (
     record_consumer_group_latency as record_consumer_group_latency_action,
 )
 from sentry_kafka_management.actions.latency.metrics import DatadogMetricsBackend
@@ -52,7 +55,7 @@ from sentry_kafka_management.brokers import YamlKafkaConfig
     "-w",
     "--max-workers",
     required=False,
-    default=128,
+    default=DEFAULT_MAX_WORKERS,
     type=click.IntRange(min=1),
     help="Maximum concurrent partition scans per cluster. Defaults to 128.",
 )

--- a/sentry_kafka_management/scripts/latency/consumer_latency.py
+++ b/sentry_kafka_management/scripts/latency/consumer_latency.py
@@ -49,6 +49,14 @@ from sentry_kafka_management.brokers import YamlKafkaConfig
     help="How long in seconds to wait before Kafka requests time out. Defaults to 10s.",
 )
 @click.option(
+    "-w",
+    "--max-workers",
+    required=False,
+    default=128,
+    type=click.IntRange(min=1),
+    help="Maximum concurrent partition scans per cluster. Defaults to 128.",
+)
+@click.option(
     "-l",
     "--log-level",
     required=False,
@@ -62,6 +70,7 @@ def consumer_latency(
     statsd_port: int,
     interval: float,
     timeout: int,
+    max_workers: int,
     log_level: str,
 ) -> None:
     """
@@ -75,10 +84,15 @@ def consumer_latency(
     kafka_config = YamlKafkaConfig(config)
     metrics_backend = DatadogMetricsBackend(statsd_host, statsd_port)
 
-    click.echo(f"Starting consumer latency collection (interval={interval:.3f}s)")
+    click.echo(
+        f"Starting consumer latency collection "
+        f"(interval={interval:.3f}s, max_workers={max_workers})"
+    )
 
     while True:
-        result = record_consumer_group_latency_action(kafka_config, metrics_backend, timeout)
+        result = record_consumer_group_latency_action(
+            kafka_config, metrics_backend, timeout, max_workers
+        )
 
         for scan in result.scans:
             click.echo(

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -627,10 +627,18 @@ def test_get_cluster_latency_continues_after_committed_offsets_error(
     admin.list_consumer_groups.return_value = _make_list_groups_result(
         valid=[_make_group_listing("group-a"), _make_group_listing("group-b")],
     )
-    admin.list_consumer_group_offsets.side_effect = [
-        {"group-a": _make_committed_offsets_future("group-a", [TopicPartition("topic-a", 0, 50)])},
-        {"group-b": _make_errored_committed_offsets_future(KafkaException("boom"))},
-    ]
+    offsets_by_group = {
+        "group-a": _make_committed_offsets_future("group-a", [TopicPartition("topic-a", 0, 50)]),
+        "group-b": _make_errored_committed_offsets_future(KafkaException("boom")),
+    }
+
+    def list_offsets(
+        reqs: list[ConsumerGroupTopicPartitions],
+    ) -> dict[str, Future[ConsumerGroupTopicPartitions]]:
+        group_id = reqs[0].group_id
+        return {group_id: offsets_by_group[group_id]}
+
+    admin.list_consumer_group_offsets.side_effect = list_offsets
 
     consumer = mock_consumer_cls.return_value
     consumer.get_watermark_offsets.return_value = (0, 100)

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -373,7 +373,7 @@ def test_get_cluster_latency_skips_own_consumer_group(
 
     assert result.scans == []
     assert result.errors is None
-    admin.list_consumer_group_offsets.assert_called_once()
+    admin.list_consumer_group_offsets.assert_not_called()
     mock_consumer_cls.assert_not_called()
 
 
@@ -570,10 +570,10 @@ def test_get_cluster_latency_continues_after_committed_offsets_error(
     admin.list_consumer_groups.return_value = _make_list_groups_result(
         valid=[_make_group_listing("group-a"), _make_group_listing("group-b")],
     )
-    admin.list_consumer_group_offsets.return_value = {
-        "group-a": _make_committed_offsets_future("group-a", [TopicPartition("topic-a", 0, 50)]),
-        "group-b": _make_errored_committed_offsets_future(KafkaException("boom")),
-    }
+    admin.list_consumer_group_offsets.side_effect = [
+        {"group-a": _make_committed_offsets_future("group-a", [TopicPartition("topic-a", 0, 50)])},
+        {"group-b": _make_errored_committed_offsets_future(KafkaException("boom"))},
+    ]
 
     consumer = mock_consumer_cls.return_value
     consumer.get_watermark_offsets.return_value = (0, 100)

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -494,8 +494,8 @@ def test_get_cluster_latency_caps_scan_workers(
     executor = MagicMock()
     mock_executor_cls.return_value.__enter__.return_value = executor
 
-    def submit(_fn, _item):
-        future = Future()
+    def submit(_fn: object, _item: object) -> Future[TopicConsumerLatency]:
+        future: Future[TopicConsumerLatency] = Future()
         future.set_result(
             TopicConsumerLatency(
                 cluster_name="cluster1",

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -87,6 +87,12 @@ def _make_committed_offsets_future(
     return future
 
 
+def _make_errored_committed_offsets_future(exc: Exception) -> Future[ConsumerGroupTopicPartitions]:
+    future: Future[ConsumerGroupTopicPartitions] = Future()
+    future.set_exception(exc)
+    return future
+
+
 def _make_errored_topic_partition(topic: str, partition: int, offset: int) -> Mock:
     bad_tp = Mock(spec=["topic", "partition", "offset", "error"])
     bad_tp.topic = topic
@@ -174,11 +180,12 @@ def test_get_committed_offsets(
         "group-a": _make_committed_offsets_future("group-a", partitions)
     }
 
+    result = get_committed_offsets(admin, ["group-a"])
+
     if raises is not None:
-        with pytest.raises(raises):
-            get_committed_offsets(admin, "group-a")
+        assert isinstance(result["group-a"], raises)
     else:
-        assert get_committed_offsets(admin, "group-a") == expected
+        assert result["group-a"] == expected
 
 
 def test_read_timestamp_ms_returns_create_time_timestamp() -> None:
@@ -366,8 +373,8 @@ def test_get_cluster_latency_skips_own_consumer_group(
 
     assert result.scans == []
     assert result.errors is None
-    admin.list_consumer_group_offsets.assert_not_called()
-    mock_consumer_cls.return_value.close.assert_called_once()
+    admin.list_consumer_group_offsets.assert_called_once()
+    mock_consumer_cls.assert_not_called()
 
 
 @patch("sentry_kafka_management.actions.latency.consumer_latency.Consumer")
@@ -439,7 +446,7 @@ def test_get_cluster_latency_reports_latency_per_partition(
         result = get_cluster_latency(
             "cluster1",
             CLUSTER_CONFIG,
-            topics={"topic-a": _topic_config(partitions=2)},
+            topics={"topic-a": _topic_config(partitions=1)},
             timeout=10,
         )
 
@@ -548,7 +555,8 @@ def test_get_cluster_latency_closes_consumer_on_error(
     assert result.errors is not None
     assert len(result.errors) == 1
     assert isinstance(result.errors[0], KafkaException)
-    mock_consumer_cls.return_value.close.assert_called_once()
+
+    mock_consumer_cls.assert_not_called()
 
 
 @patch("sentry_kafka_management.actions.latency.consumer_latency.Consumer")
@@ -562,10 +570,10 @@ def test_get_cluster_latency_continues_after_committed_offsets_error(
     admin.list_consumer_groups.return_value = _make_list_groups_result(
         valid=[_make_group_listing("group-a"), _make_group_listing("group-b")],
     )
-    admin.list_consumer_group_offsets.side_effect = [
-        {"group-a": _make_committed_offsets_future("group-a", [TopicPartition("topic-a", 0, 50)])},
-        KafkaException("boom"),
-    ]
+    admin.list_consumer_group_offsets.return_value = {
+        "group-a": _make_committed_offsets_future("group-a", [TopicPartition("topic-a", 0, 50)]),
+        "group-b": _make_errored_committed_offsets_future(KafkaException("boom")),
+    }
 
     consumer = mock_consumer_cls.return_value
     consumer.get_watermark_offsets.return_value = (0, 100)
@@ -739,19 +747,20 @@ def test_record_consumer_group_latency_emits_one_histogram_per_scan(
         "cluster1": {"topic-a": {}},
         "cluster2": {"topic-b": {}},
     }[name]
-    mock_get_cluster_latency.side_effect = [
-        ConsumerLatencyResult(
+    cluster_results = {
+        "cluster1": ConsumerLatencyResult(
             scans=[
                 TopicConsumerLatency("cluster1", "topic-a", "group-a", 100.0, partition=0),
                 TopicConsumerLatency("cluster1", "topic-a", "group-b", 200.0, partition=1),
             ],
         ),
-        ConsumerLatencyResult(
+        "cluster2": ConsumerLatencyResult(
             scans=[
                 TopicConsumerLatency("cluster2", "topic-b", "group-c", 50.0, partition=2),
             ],
         ),
-    ]
+    }
+    mock_get_cluster_latency.side_effect = lambda name, *a, **k: cluster_results[name]
     metrics = FakeMetricsBackend()
 
     result = record_consumer_group_latency(config, metrics)
@@ -795,17 +804,18 @@ def test_record_consumer_group_latency_emits_good_clusters_with_errors(
         "cluster1": {"topic-a": {}},
         "cluster2": {"topic-b": {}},
     }[name]
-    mock_get_cluster_latency.side_effect = [
-        ConsumerLatencyResult(
+    cluster_results = {
+        "cluster1": ConsumerLatencyResult(
             scans=[TopicConsumerLatency("cluster1", "topic-a", "group-a", 100.0, partition=0)],
         ),
-        ConsumerLatencyResult(
+        "cluster2": ConsumerLatencyResult(
             scans=[
                 TopicConsumerLatency("cluster2", "topic-b", "group-b", 50.0, partition=1),
             ],
             errors=[KafkaException("boom")],
         ),
-    ]
+    }
+    mock_get_cluster_latency.side_effect = lambda name, *a, **k: cluster_results[name]
     metrics = FakeMetricsBackend()
 
     result = record_consumer_group_latency(config, metrics)
@@ -834,12 +844,13 @@ def test_record_consumer_group_latency_emits_good_clusters_on_total_cluster_fail
         "cluster1": {"topic-a": {}},
         "cluster2": {"topic-b": {}},
     }[name]
-    mock_get_cluster_latency.side_effect = [
-        ConsumerLatencyResult(
+    cluster_results = {
+        "cluster1": ConsumerLatencyResult(
             scans=[TopicConsumerLatency("cluster1", "topic-a", "group-a", 100.0, partition=0)],
         ),
-        ConsumerLatencyResult(scans=[], errors=[KafkaException("cluster unreachable")]),
-    ]
+        "cluster2": ConsumerLatencyResult(scans=[], errors=[KafkaException("cluster unreachable")]),
+    }
+    mock_get_cluster_latency.side_effect = lambda name, *a, **k: cluster_results[name]
     metrics = FakeMetricsBackend()
 
     result = record_consumer_group_latency(config, metrics)

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -469,6 +469,59 @@ def test_get_cluster_latency_reports_latency_per_partition(
     assert result.errors is None
 
 
+@patch("sentry_kafka_management.actions.latency.consumer_latency.ThreadPoolExecutor")
+@patch("sentry_kafka_management.actions.latency.consumer_latency.Consumer")
+@patch("sentry_kafka_management.actions.latency.consumer_latency.get_admin_client")
+def test_get_cluster_latency_caps_scan_workers(
+    mock_get_admin: MagicMock,
+    mock_consumer_cls: MagicMock,
+    mock_executor_cls: MagicMock,
+) -> None:
+    admin = Mock()
+    mock_get_admin.return_value = admin
+    admin.list_consumer_groups.return_value = _make_list_groups_result(
+        valid=[_make_group_listing("group-a")],
+    )
+    partitions = [TopicPartition("topic-a", p, 50) for p in range(10)]
+    admin.list_consumer_group_offsets.return_value = {
+        "group-a": _make_committed_offsets_future("group-a", partitions),
+    }
+
+    consumer = mock_consumer_cls.return_value
+    consumer.get_watermark_offsets.return_value = (0, 100)
+    consumer.poll.return_value = _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 800))
+
+    executor = MagicMock()
+    mock_executor_cls.return_value.__enter__.return_value = executor
+
+    def submit(_fn, _item):
+        future = Future()
+        future.set_result(
+            TopicConsumerLatency(
+                cluster_name="cluster1",
+                group_id="group-a",
+                topic_name="topic-a",
+                latency_ms=0.0,
+                partition=0,
+            )
+        )
+        return future
+
+    executor.submit.side_effect = submit
+
+    with patch("time.time", return_value=1.0):
+        get_cluster_latency(
+            "cluster1",
+            CLUSTER_CONFIG,
+            topics={"topic-a": _topic_config(partitions=10)},
+            timeout=10,
+            max_workers=4,
+        )
+
+    scan_call = mock_executor_cls.call_args_list[0]
+    assert scan_call.kwargs["max_workers"] == 4
+
+
 @patch("sentry_kafka_management.actions.latency.consumer_latency.Consumer")
 @patch("sentry_kafka_management.actions.latency.consumer_latency.get_admin_client")
 def test_get_cluster_latency_skips_uncommitted_partitions(

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -494,15 +494,19 @@ def test_get_cluster_latency_caps_scan_workers(
     executor = MagicMock()
     mock_executor_cls.return_value.__enter__.return_value = executor
 
-    def submit(_fn: object, _item: object) -> Future[TopicConsumerLatency]:
-        future: Future[TopicConsumerLatency] = Future()
+    def submit(_fn: object, *args: object) -> Future[ConsumerLatencyResult]:
+        future: Future[ConsumerLatencyResult] = Future()
         future.set_result(
-            TopicConsumerLatency(
-                cluster_name="cluster1",
-                group_id="group-a",
-                topic_name="topic-a",
-                latency_ms=0.0,
-                partition=0,
+            ConsumerLatencyResult(
+                scans=[
+                    TopicConsumerLatency(
+                        cluster_name="cluster1",
+                        group_id="group-a",
+                        topic_name="topic-a",
+                        latency_ms=0.0,
+                        partition=0,
+                    )
+                ],
             )
         )
         return future

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -372,7 +372,7 @@ def test_get_cluster_latency_skips_own_consumer_group(
     )
 
     assert result.scans == []
-    assert result.errors is None
+    assert len(result.errors) == 0
     admin.list_consumer_group_offsets.assert_not_called()
     mock_consumer_cls.assert_not_called()
 
@@ -408,7 +408,7 @@ def test_get_cluster_latency_filters_unconfigured_topics(
         )
 
     assert [scan.topic_name for scan in result.scans] == ["topic-a"]
-    assert result.errors is None
+    assert len(result.errors) == 0
     for call in consumer.get_watermark_offsets.call_args_list:
         assert call.args[0].topic == "topic-a"
 
@@ -466,7 +466,7 @@ def test_get_cluster_latency_reports_latency_per_partition(
             partition=1,
         ),
     ]
-    assert result.errors is None
+    assert len(result.errors) == 0
 
 
 @patch("sentry_kafka_management.actions.latency.consumer_latency.ThreadPoolExecutor")
@@ -559,7 +559,7 @@ def test_get_cluster_latency_skips_uncommitted_partitions(
             partition=0,
         ),
     ]
-    assert result.errors is None
+    assert len(result.errors) == 0
     consumer.get_watermark_offsets.assert_called_once()
 
 
@@ -586,7 +586,7 @@ def test_get_cluster_latency_skips_groups_with_no_matching_topics(
     )
 
     assert result.scans == []
-    assert result.errors is None
+    assert len(result.errors) == 0
     mock_consumer_cls.return_value.get_watermark_offsets.assert_not_called()
 
 
@@ -736,7 +736,7 @@ def test_get_cluster_latency_uses_per_topic_retention_when_aged_out(
         timeout=10,
     )
 
-    assert result.errors is None
+    assert len(result.errors) == 0
     assert {(s.topic_name, s.latency_ms) for s in result.scans} == {
         ("topic-short", 5_000.0),
         ("topic-long", 86_400_000.0),
@@ -775,7 +775,7 @@ def test_get_cluster_latency_uses_default_retention_when_unset(
         timeout=10,
     )
 
-    assert result.errors is None
+    assert len(result.errors) == 0
     assert result.scans == [
         TopicConsumerLatency(
             cluster_name="cluster1",
@@ -819,7 +819,7 @@ def test_record_consumer_group_latency_emits_one_histogram_per_scan(
     result = record_consumer_group_latency(config, metrics)
 
     assert len(result.scans) == 3
-    assert result.errors is None
+    assert len(result.errors) == 0
     assert [latency for _, latency, _ in metrics.histograms] == [100.0, 200.0, 50.0]
     cluster_tags = [tags["cluster"] for _, _, tags in metrics.histograms if tags]
     assert cluster_tags == ["cluster1", "cluster1", "cluster2"]
@@ -840,7 +840,7 @@ def test_record_consumer_group_latency_emits_nothing_when_no_clusters_have_laten
     result = record_consumer_group_latency(config, metrics)
 
     assert result.scans == []
-    assert result.errors is None
+    assert len(result.errors) == 0
     assert metrics.histograms == []
 
 

--- a/tests/scripts/test_latency.py
+++ b/tests/scripts/test_latency.py
@@ -60,6 +60,39 @@ def test_consumer_latency_runs_collection_loop_and_emits_metrics(
 
 
 @patch("sentry_kafka_management.scripts.latency.consumer_latency.DatadogMetricsBackend")
+@patch(
+    "sentry_kafka_management.scripts.latency.consumer_latency.record_consumer_group_latency_action"
+)
+@patch("time.sleep")
+def test_consumer_latency_passes_max_workers(
+    mock_sleep: MagicMock,
+    mock_record: MagicMock,
+    mock_metrics_backend_cls: MagicMock,
+    temp_config: Path,
+) -> None:
+    mock_record.return_value = ConsumerLatencyResult(scans=[])
+    mock_sleep.side_effect = KeyboardInterrupt
+
+    result = CliRunner().invoke(
+        consumer_latency,
+        [
+            "--config",
+            str(temp_config),
+            "--statsd-host",
+            "localhost",
+            "--statsd-port",
+            "8126",
+            "--max-workers",
+            "32",
+        ],
+    )
+
+    assert result.exit_code != 0
+    mock_record.assert_called_once()
+    assert mock_record.call_args.args[3] == 32
+
+
+@patch("sentry_kafka_management.scripts.latency.consumer_latency.DatadogMetricsBackend")
 @patch("sentry_kafka_management.actions.latency.consumer_latency.get_cluster_latency")
 @patch("time.sleep")
 def test_consumer_latency_handles_iterations_with_no_scans(


### PR DESCRIPTION
Changes:

1. Fetches committed offsets in a batch rather than individual calls
2. Uses multithreading to record latency from each cluster at a time
3. Uses multithreading to record latency from each partition at a time
4. Limits (softly) the amount of data fetched to as little as possible (1 batch)