### PR TITLE
Add Sentry SDK and optimize consumer latency polling.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "PyYAML",
   "click>=8.0.0",
   "datadog>=0.49.1",
+  "sentry-sdk>=2.0.0",
 ]
 
 [project.scripts]

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -162,6 +162,13 @@ def scan_partition_latencies(
         if key not in pending:
             continue
 
+        # We only need one message per partition to record latency. Our
+        # consumer is assigned every partition at once, so without
+        # pausing the broker keeps fetching from partitions we've already
+        # scanned and poll() returns useless messages. These messages can
+        # flood the queue and prevent unscanned partitions from being fetched.
+        # Pausing scanned partitions prevents this blocking from happening.
+
         error = msg.error()
         if error is not None:
             code = error.code()

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -155,7 +155,10 @@ def scan_partition_latencies(
         if msg is None:
             continue
 
-        key = (msg.topic(), msg.partition())
+        msg_topic = msg.topic()
+        msg_partition = msg.partition()
+
+        key = (msg_topic, msg_partition)
         if key not in pending:
             continue
 
@@ -171,6 +174,7 @@ def scan_partition_latencies(
             else:
                 errors.append(KafkaException(error))
             pending.discard(key)
+            consumer.pause([TopicPartition(msg_topic, msg_partition)])
             continue
 
         ts_type, ts_ms = msg.timestamp()
@@ -181,6 +185,7 @@ def scan_partition_latencies(
         else:
             latencies[key] = float(int(time.time() * 1000) - int(ts_ms))
         pending.discard(key)
+        consumer.pause([TopicPartition(msg_topic, msg_partition)])
 
     for topic, partition in pending:
         errors.append(TimeoutError(f"Timed out reading timestamp for {topic}[{partition}]"))

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -42,12 +42,6 @@ RETRYABLE_ERRORS = frozenset(
 
 
 @dataclass
-class TimestampRead:
-    ts_ms: int
-    read_at_ms: int
-
-
-@dataclass
 class PartitionScan:
     group_id: str
     topic: str
@@ -140,16 +134,17 @@ def get_committed_offsets(
     return results
 
 
-def read_committed_timestamps(
+def scan_partition_latencies(
     consumer: Consumer,
     scans: list[PartitionScan],
     timeout: int,
-) -> tuple[dict[tuple[str, int], TimestampRead], list[Exception]]:
-    """Read the message timestamp at each scan's committed offset."""
-    reads: dict[tuple[str, int], TimestampRead] = {}
+) -> tuple[dict[tuple[str, int], float], list[Exception]]:
+    """Classify each partition's consumer latency from a single poll loop."""
+    latencies: dict[tuple[str, int], float] = {}
     errors: list[Exception] = []
 
-    pending = {(scan.topic, scan.partition) for scan in scans}
+    retention_by_key = {(scan.topic, scan.partition): scan.retention_ms for scan in scans}
+    pending = set(retention_by_key)
     consumer.assign(
         [TopicPartition(scan.topic, scan.partition, scan.committed_offset) for scan in scans]
     )
@@ -166,9 +161,15 @@ def read_committed_timestamps(
 
         error = msg.error()
         if error is not None:
-            if error.code() in RETRYABLE_ERRORS:
+            code = error.code()
+            if code in RETRYABLE_ERRORS:
                 continue
-            errors.append(KafkaException(error))
+            if code == KafkaError._PARTITION_EOF:
+                latencies[key] = 0.0
+            elif code == KafkaError._AUTO_OFFSET_RESET:
+                latencies[key] = float(retention_by_key[key])
+            else:
+                errors.append(KafkaException(error))
             pending.discard(key)
             continue
 
@@ -178,13 +179,13 @@ def read_committed_timestamps(
         elif ts_ms < 0:
             errors.append(ValueError(f"Invalid timestamp {ts_ms} for {key[0]}[{key[1]}]"))
         else:
-            reads[key] = TimestampRead(ts_ms=int(ts_ms), read_at_ms=int(time.time() * 1000))
+            latencies[key] = float(int(time.time() * 1000) - int(ts_ms))
         pending.discard(key)
 
     for topic, partition in pending:
         errors.append(TimeoutError(f"Timed out reading timestamp for {topic}[{partition}]"))
 
-    return reads, errors
+    return latencies, errors
 
 
 def get_consumer_group_latency(
@@ -223,24 +224,12 @@ def get_consumer_group_latency(
 
     consumer = Consumer(dict(consumer_config))
     try:
-        to_read: list[PartitionScan] = []
+        latencies, scan_errors = scan_partition_latencies(consumer, group_scans, timeout)
+        errors.extend(scan_errors)
         for item in group_scans:
-            try:
-                low, high = consumer.get_watermark_offsets(
-                    TopicPartition(item.topic, item.partition), timeout=timeout, cached=False
-                )
-            except Exception as e:
-                errors.append(e)
+            latency_ms = latencies.get((item.topic, item.partition))
+            if latency_ms is None:
                 continue
-
-            if high <= item.committed_offset:
-                latency_ms = 0.0  # Caught up regardless of retention
-            elif item.committed_offset < low:
-                latency_ms = float(item.retention_ms)  # Aged out of retention
-            else:
-                to_read.append(item)
-                continue
-
             scans.append(
                 TopicConsumerLatency(
                     cluster_name=cluster_name,
@@ -250,23 +239,6 @@ def get_consumer_group_latency(
                     partition=item.partition,
                 )
             )
-
-        if to_read:
-            reads, read_errors = read_committed_timestamps(consumer, to_read, timeout)
-            errors.extend(read_errors)
-            for item in to_read:
-                read = reads.get((item.topic, item.partition))
-                if read is None:
-                    continue
-                scans.append(
-                    TopicConsumerLatency(
-                        cluster_name=cluster_name,
-                        group_id=item.group_id,
-                        topic_name=item.topic,
-                        latency_ms=float(read.read_at_ms - read.ts_ms),
-                        partition=item.partition,
-                    )
-                )
     finally:
         try:
             consumer.close()
@@ -296,8 +268,13 @@ def get_cluster_latency(
         else:
             retentions_by_topic[topic_name] = int(retention_ms)
 
+    # enable.partition.eof: ensures that _PARTITION_EOF is raised on poll consumer is caught up
+    # auto.offset.reset: ensures _AUTO_OFFSET_RESET is raised on poll consumer is out of retention
+
     consumer_config = {
         "enable.auto.commit": False,
+        "enable.partition.eof": True,
+        "auto.offset.reset": "error",
         "group.id": consumer_group_id,
         **build_broker_config(config),
     }

--- a/sentry_kafka_management/cli.py
+++ b/sentry_kafka_management/cli.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+
 import click
 import sentry_sdk
 
@@ -31,11 +33,6 @@ from sentry_kafka_management.scripts.topics.healthcheck import (
 from sentry_kafka_management.scripts.topics.partitions import elect_partition_leaders
 from sentry_kafka_management.scripts.topics.placement import compute_topic_placement
 
-SENTRY_DSN = (
-    "https://93b0938702b2a9c18ffd9312643a1e5b"
-    "@o4510127168028672.ingest.s4s2.sentry.io/4510749467607136"
-)
-
 COMMANDS = [
     apply_configs,
     compute_topic_placement,
@@ -61,7 +58,7 @@ def main(ctx: click.Context) -> None:
     """
     CLI entrypoint for sentry-kafka-management.
     """
-    sentry_sdk.init(dsn=SENTRY_DSN, release=__version__)
+    sentry_sdk.init(dsn=os.environ.get("SENTRY_DSN"), release=__version__)
     if ctx.invoked_subcommand is not None:
         sentry_sdk.set_tag("command", ctx.invoked_subcommand)
 

--- a/sentry_kafka_management/cli.py
+++ b/sentry_kafka_management/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import click
+import sentry_sdk
 
 from sentry_kafka_management import __version__
 from sentry_kafka_management.scripts.brokers.configs import (
@@ -30,6 +31,11 @@ from sentry_kafka_management.scripts.topics.healthcheck import (
 from sentry_kafka_management.scripts.topics.partitions import elect_partition_leaders
 from sentry_kafka_management.scripts.topics.placement import compute_topic_placement
 
+SENTRY_DSN = (
+    "https://93b0938702b2a9c18ffd9312643a1e5b"
+    "@o4510127168028672.ingest.s4s2.sentry.io/4510749467607136"
+)
+
 COMMANDS = [
     apply_configs,
     compute_topic_placement,
@@ -50,11 +56,14 @@ COMMANDS = [
 
 @click.group()
 @click.version_option(version=__version__, prog_name="sentry-kafka-management")
-def main() -> None:
+@click.pass_context
+def main(ctx: click.Context) -> None:
     """
     CLI entrypoint for sentry-kafka-management.
     """
-    pass
+    sentry_sdk.init(dsn=SENTRY_DSN, release=__version__)
+    if ctx.invoked_subcommand is not None:
+        sentry_sdk.set_tag("command", ctx.invoked_subcommand)
 
 
 for command in COMMANDS:

--- a/sentry_kafka_management/scripts/latency/consumer_latency.py
+++ b/sentry_kafka_management/scripts/latency/consumer_latency.py
@@ -94,9 +94,13 @@ def consumer_latency(
     )
 
     while True:
-        result = record_consumer_group_latency_action(
-            kafka_config, metrics_backend, timeout, max_workers
-        )
+        try:
+            result = record_consumer_group_latency_action(
+                kafka_config, metrics_backend, timeout, max_workers
+            )
+        except Exception:
+            sentry_sdk.capture_exception()
+            raise
 
         for scan in result.scans:
             click.echo(

--- a/sentry_kafka_management/scripts/latency/consumer_latency.py
+++ b/sentry_kafka_management/scripts/latency/consumer_latency.py
@@ -5,6 +5,7 @@ import time
 from pathlib import Path
 
 import click
+import sentry_sdk
 
 from sentry_kafka_management.actions.latency.consumer_latency import (
     DEFAULT_MAX_WORKERS,
@@ -110,6 +111,7 @@ def consumer_latency(
         if result.errors:
             for error in result.errors:
                 click.echo(f"Error: {error}", err=True)
+                sentry_sdk.capture_exception(error)
             raise click.ClickException(
                 f"Consumer latency collection failed ({len(result.errors)} error(s))"
             )

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -26,8 +26,8 @@ from sentry_kafka_management.actions.latency.consumer_latency import (
     get_cluster_latency,
     get_committed_offsets,
     list_consumer_group_ids,
-    read_committed_timestamps,
     record_consumer_group_latency,
+    scan_partition_latencies,
 )
 from sentry_kafka_management.actions.latency.metrics import MetricsBackend, Tags
 from sentry_kafka_management.brokers import ClusterConfig, TopicConfig
@@ -206,32 +206,60 @@ def test_get_committed_offsets(
         assert result["group-a"] == expected
 
 
-def test_read_committed_timestamps_returns_create_time_timestamp() -> None:
+def test_scan_partition_latencies_returns_latency_from_create_time() -> None:
     consumer = Mock()
     consumer.poll.return_value = _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 1_700_000_000_000))
 
-    reads, errors = read_committed_timestamps(consumer, [_scan(committed_offset=42)], timeout=10)
+    with patch("time.time", return_value=1_700_000_000.5):
+        latencies, errors = scan_partition_latencies(
+            consumer, [_scan(committed_offset=42)], timeout=10
+        )
 
-    assert reads[("topic-a", 0)].ts_ms == 1_700_000_000_000
+    assert latencies == {("topic-a", 0): 500.0}
     assert errors == []
     consumer.assign.assert_called_once()
     (assigned,) = consumer.assign.call_args.args
     assert assigned == [TopicPartition("topic-a", 0, 42)]
 
 
-def test_read_committed_timestamps_returns_log_append_time_timestamp() -> None:
+def test_scan_partition_latencies_returns_latency_from_log_append_time() -> None:
     consumer = Mock()
     consumer.poll.return_value = _make_message(
         timestamp=(TIMESTAMP_LOG_APPEND_TIME, 1_700_000_000_500)
     )
 
-    reads, errors = read_committed_timestamps(consumer, [_scan()], timeout=10)
+    with patch("time.time", return_value=1_700_000_001.0):
+        latencies, errors = scan_partition_latencies(consumer, [_scan()], timeout=10)
 
-    assert reads[("topic-a", 0)].ts_ms == 1_700_000_000_500
+    assert latencies == {("topic-a", 0): 500.0}
     assert errors == []
 
 
-def test_read_committed_timestamps_assigns_all_partitions_in_one_batch() -> None:
+def test_scan_partition_latencies_caught_up_partition_is_zero() -> None:
+    consumer = Mock()
+    consumer.poll.return_value = _make_message(
+        error=KafkaError(KafkaError._PARTITION_EOF, "reached end of partition"),
+    )
+
+    latencies, errors = scan_partition_latencies(consumer, [_scan()], timeout=10)
+
+    assert latencies == {("topic-a", 0): 0.0}
+    assert errors == []
+
+
+def test_scan_partition_latencies_aged_out_uses_retention() -> None:
+    consumer = Mock()
+    consumer.poll.return_value = _make_message(
+        error=KafkaError(KafkaError._AUTO_OFFSET_RESET, "Offset out of range"),
+    )
+
+    latencies, errors = scan_partition_latencies(consumer, [_scan(retention_ms=5_000)], timeout=10)
+
+    assert latencies == {("topic-a", 0): 5_000.0}
+    assert errors == []
+
+
+def test_scan_partition_latencies_assigns_all_partitions_in_one_batch() -> None:
     consumer = Mock()
     consumer.poll.side_effect = [
         _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 10), partition=0),
@@ -239,19 +267,17 @@ def test_read_committed_timestamps_assigns_all_partitions_in_one_batch() -> None
     ]
 
     scans = [_scan(partition=0, committed_offset=5), _scan(partition=1, committed_offset=7)]
-    reads, errors = read_committed_timestamps(consumer, scans, timeout=10)
+    with patch("time.time", return_value=1.0):
+        latencies, errors = scan_partition_latencies(consumer, scans, timeout=10)
 
-    assert {key: read.ts_ms for key, read in reads.items()} == {
-        ("topic-a", 0): 10,
-        ("topic-a", 1): 20,
-    }
+    assert latencies == {("topic-a", 0): 990.0, ("topic-a", 1): 980.0}
     assert errors == []
     consumer.assign.assert_called_once()
     (assigned,) = consumer.assign.call_args.args
     assert assigned == [TopicPartition("topic-a", 0, 5), TopicPartition("topic-a", 1, 7)]
 
 
-def test_read_committed_timestamps_skips_empty_polls_then_returns() -> None:
+def test_scan_partition_latencies_skips_empty_polls_then_returns() -> None:
     consumer = Mock()
     consumer.poll.side_effect = [
         None,
@@ -259,71 +285,73 @@ def test_read_committed_timestamps_skips_empty_polls_then_returns() -> None:
         _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 5)),
     ]
 
-    reads, errors = read_committed_timestamps(consumer, [_scan()], timeout=10)
+    with patch("time.time", return_value=1.0):
+        latencies, errors = scan_partition_latencies(consumer, [_scan()], timeout=10)
 
-    assert reads[("topic-a", 0)].ts_ms == 5
+    assert latencies == {("topic-a", 0): 995.0}
     assert consumer.poll.call_count == 3
 
 
-def test_read_committed_timestamps_records_message_error() -> None:
+def test_scan_partition_latencies_records_message_error() -> None:
     consumer = Mock()
     consumer.poll.return_value = _make_message(
         error=KafkaError(KafkaError.UNKNOWN, "fetch failed"),
     )
 
-    reads, errors = read_committed_timestamps(consumer, [_scan()], timeout=10)
+    latencies, errors = scan_partition_latencies(consumer, [_scan()], timeout=10)
 
-    assert reads == {}
+    assert latencies == {}
     assert len(errors) == 1
     assert isinstance(errors[0], KafkaException)
 
 
-def test_read_committed_timestamps_retries_on_retryable_error() -> None:
+def test_scan_partition_latencies_retries_on_retryable_error() -> None:
     consumer = Mock()
     consumer.poll.side_effect = [
         _make_message(error=KafkaError(KafkaError.REQUEST_TIMED_OUT, "request timed out")),
         _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 9)),
     ]
 
-    reads, errors = read_committed_timestamps(consumer, [_scan()], timeout=10)
+    with patch("time.time", return_value=1.0):
+        latencies, errors = scan_partition_latencies(consumer, [_scan()], timeout=10)
 
-    assert reads[("topic-a", 0)].ts_ms == 9
+    assert latencies == {("topic-a", 0): 991.0}
     assert errors == []
     assert consumer.poll.call_count == 2
 
 
-def test_read_committed_timestamps_records_timestamp_not_available() -> None:
+def test_scan_partition_latencies_records_timestamp_not_available() -> None:
     consumer = Mock()
     consumer.poll.return_value = _make_message(timestamp=(TIMESTAMP_NOT_AVAILABLE, 0))
 
-    reads, errors = read_committed_timestamps(consumer, [_scan()], timeout=10)
+    latencies, errors = scan_partition_latencies(consumer, [_scan()], timeout=10)
 
-    assert reads == {}
+    assert latencies == {}
     assert len(errors) == 1
     assert isinstance(errors[0], ValueError)
     assert "Timestamp not available" in str(errors[0])
 
 
-def test_read_committed_timestamps_records_negative_timestamp() -> None:
+def test_scan_partition_latencies_records_negative_timestamp() -> None:
     consumer = Mock()
     consumer.poll.return_value = _make_message(timestamp=(TIMESTAMP_CREATE_TIME, -1))
 
-    reads, errors = read_committed_timestamps(consumer, [_scan()], timeout=10)
+    latencies, errors = scan_partition_latencies(consumer, [_scan()], timeout=10)
 
-    assert reads == {}
+    assert latencies == {}
     assert len(errors) == 1
     assert isinstance(errors[0], ValueError)
     assert "Invalid timestamp" in str(errors[0])
 
 
-def test_read_committed_timestamps_records_timeout_for_unread_partitions() -> None:
+def test_scan_partition_latencies_records_timeout_for_unread_partitions() -> None:
     consumer = Mock()
     consumer.poll.return_value = None
 
     with patch("time.monotonic", side_effect=[0.0, 0.5, 100.0]):
-        reads, errors = read_committed_timestamps(consumer, [_scan()], timeout=10)
+        latencies, errors = scan_partition_latencies(consumer, [_scan()], timeout=10)
 
-    assert reads == {}
+    assert latencies == {}
     assert len(errors) == 1
     assert isinstance(errors[0], TimeoutError)
 
@@ -373,7 +401,6 @@ def test_get_cluster_latency_filters_unconfigured_topics(
     }
 
     consumer = mock_consumer_cls.return_value
-    consumer.get_watermark_offsets.return_value = (10, 100)
     consumer.poll.return_value = _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 0))
 
     with patch("time.time", return_value=1.0):
@@ -383,8 +410,9 @@ def test_get_cluster_latency_filters_unconfigured_topics(
 
     assert [scan.topic_name for scan in result.scans] == ["topic-a"]
     assert len(result.errors) == 0
-    for call in consumer.get_watermark_offsets.call_args_list:
-        assert call.args[0].topic == "topic-a"
+    for call in consumer.assign.call_args_list:
+        for assigned in call.args[0]:
+            assert assigned.topic == "topic-a"
 
 
 @patch("sentry_kafka_management.actions.latency.consumer_latency.Consumer")
@@ -409,8 +437,6 @@ def test_get_cluster_latency_reports_latency_per_partition(
     }
 
     consumer = mock_consumer_cls.return_value
-    consumer.get_watermark_offsets.return_value = (0, 100)
-
     consumer.poll.side_effect = [
         _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 800), partition=0),
         _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 0), partition=1),
@@ -462,7 +488,6 @@ def test_get_cluster_latency_caps_scan_workers(
     }
 
     consumer = mock_consumer_cls.return_value
-    consumer.get_watermark_offsets.return_value = (0, 100)
     consumer.poll.return_value = _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 800))
 
     executor = MagicMock()
@@ -519,7 +544,9 @@ def test_get_cluster_latency_skips_uncommitted_partitions(
     }
 
     consumer = mock_consumer_cls.return_value
-    consumer.get_watermark_offsets.return_value = (0, 100)
+    consumer.poll.return_value = _make_message(
+        error=KafkaError(KafkaError._PARTITION_EOF, "reached end of partition"),
+    )
 
     result = get_cluster_latency(
         "cluster1",
@@ -538,7 +565,7 @@ def test_get_cluster_latency_skips_uncommitted_partitions(
         ),
     ]
     assert len(result.errors) == 0
-    consumer.get_watermark_offsets.assert_called_once()
+    consumer.assign.assert_called_once()
 
 
 @patch("sentry_kafka_management.actions.latency.consumer_latency.Consumer")
@@ -565,7 +592,7 @@ def test_get_cluster_latency_skips_groups_with_no_matching_topics(
 
     assert result.scans == []
     assert len(result.errors) == 0
-    mock_consumer_cls.return_value.get_watermark_offsets.assert_not_called()
+    mock_consumer_cls.return_value.poll.assert_not_called()
 
 
 @patch("sentry_kafka_management.actions.latency.consumer_latency.Consumer")
@@ -615,7 +642,6 @@ def test_get_cluster_latency_continues_after_committed_offsets_error(
     admin.list_consumer_group_offsets.side_effect = list_offsets
 
     consumer = mock_consumer_cls.return_value
-    consumer.get_watermark_offsets.return_value = (0, 100)
     consumer.poll.return_value = _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 800))
 
     with patch("time.time", return_value=1.0):
@@ -659,14 +685,10 @@ def test_get_cluster_latency_continues_after_partition_latency_error(
     }
 
     consumer = mock_consumer_cls.return_value
-
-    def watermark_offsets(tp: TopicPartition, **kwargs: object) -> tuple[int, int]:
-        if tp.partition == 1:
-            raise KafkaException("watermark lookup failed")
-        return (0, 100)
-
-    consumer.get_watermark_offsets.side_effect = watermark_offsets
-    consumer.poll.return_value = _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 800))
+    consumer.poll.side_effect = [
+        _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 800), partition=0),
+        _make_message(error=KafkaError(KafkaError.UNKNOWN, "fetch failed"), partition=1),
+    ]
 
     with patch("time.time", return_value=1.0):
         result = get_cluster_latency(
@@ -710,7 +732,18 @@ def test_get_cluster_latency_uses_per_topic_retention_when_aged_out(
             ],
         ),
     }
-    mock_consumer_cls.return_value.get_watermark_offsets.return_value = (100, 200)
+    mock_consumer_cls.return_value.poll.side_effect = [
+        _make_message(
+            error=KafkaError(KafkaError._AUTO_OFFSET_RESET, "Offset out of range"),
+            topic="topic-short",
+            partition=0,
+        ),
+        _make_message(
+            error=KafkaError(KafkaError._AUTO_OFFSET_RESET, "Offset out of range"),
+            topic="topic-long",
+            partition=0,
+        ),
+    ]
 
     result = get_cluster_latency(
         "cluster1",
@@ -746,7 +779,11 @@ def test_get_cluster_latency_uses_default_retention_when_unset(
             [TopicPartition("topic-no-retention", 0, 5)],
         ),
     }
-    mock_consumer_cls.return_value.get_watermark_offsets.return_value = (100, 200)
+    mock_consumer_cls.return_value.poll.return_value = _make_message(
+        error=KafkaError(KafkaError._AUTO_OFFSET_RESET, "Offset out of range"),
+        topic="topic-no-retention",
+        partition=0,
+    )
     no_retention_topic = TopicConfig(
         partitions=1,
         placement=1,

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -344,6 +344,21 @@ def test_scan_partition_latencies_records_negative_timestamp() -> None:
     assert "Invalid timestamp" in str(errors[0])
 
 
+def test_scan_partition_latencies_pauses_each_partition_once_resolved() -> None:
+    consumer = Mock()
+    consumer.poll.side_effect = [
+        _make_message(timestamp=(TIMESTAMP_CREATE_TIME, 10), partition=0),
+        _make_message(error=KafkaError(KafkaError._PARTITION_EOF, "eof"), partition=1),
+    ]
+
+    scans = [_scan(partition=0, committed_offset=5), _scan(partition=1, committed_offset=9)]
+    with patch("time.time", return_value=1.0):
+        scan_partition_latencies(consumer, scans, timeout=10)
+
+    paused = [call.args[0] for call in consumer.pause.call_args_list]
+    assert paused == [[TopicPartition("topic-a", 0)], [TopicPartition("topic-a", 1)]]
+
+
 def test_scan_partition_latencies_records_timeout_for_unread_partitions() -> None:
     consumer = Mock()
     consumer.poll.return_value = None

--- a/uv.lock
+++ b/uv.lock
@@ -365,6 +365,7 @@ dependencies = [
     { name = "confluent-kafka", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "datadog", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
     { name = "pyyaml", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
+    { name = "sentry-sdk", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 
 [package.dev-dependencies]
@@ -386,6 +387,7 @@ requires-dist = [
     { name = "confluent-kafka", specifier = ">=2.8.0" },
     { name = "datadog", specifier = ">=0.49.1" },
     { name = "pyyaml" },
+    { name = "sentry-sdk", specifier = ">=2.0.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Adds Sentry dependency to the project and auto initializes for commands. Changes how latency recording works to avoid fetching watermark offsets and instead configures the poll to raise errors when the consumer is caught up or lagged beyond retention (edge cases that offsets were needed for).

Also uses `consumer.pause` to stop fetching from processed (topic, partition) so that they do not fill up the fetch queue and block others from being processed.