### PR TITLE
fix(consumer-latency): clean process exiting / --clusters

### DIFF
--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -5,7 +5,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Collection, Mapping
+from typing import Mapping
 
 from confluent_kafka import (  # type: ignore[import-untyped]
     TIMESTAMP_NOT_AVAILABLE,
@@ -363,7 +363,7 @@ def record_consumer_group_latency(
     timeout: int = 10,
     max_workers: int = DEFAULT_MAX_WORKERS,
     stop_event: threading.Event | None = None,
-    clusters: Collection[str] | None = None,
+    clusters: tuple[str, ...] | None = None,
 ) -> ConsumerLatencyResult:
     scans: list[TopicConsumerLatency] = []
     errors: list[Exception] = []

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -138,6 +139,7 @@ def scan_partition_latencies(
     consumer: Consumer,
     scans: list[PartitionScan],
     timeout: int,
+    stop_event: threading.Event | None = None,
 ) -> tuple[dict[tuple[str, int], float], list[Exception]]:
     """Classify each partition's consumer latency from a single poll loop."""
     latencies: dict[tuple[str, int], float] = {}
@@ -151,6 +153,8 @@ def scan_partition_latencies(
 
     deadline = time.monotonic() + timeout
     while pending and time.monotonic() < deadline:
+        if stop_event is not None and stop_event.is_set():
+            return latencies, errors
         msg = consumer.poll(1.0)
         if msg is None:
             continue
@@ -207,12 +211,16 @@ def get_consumer_group_latency(
     group_id: str,
     retentions_by_topic: Mapping[str, int],
     timeout: int,
+    stop_event: threading.Event | None = None,
 ) -> ConsumerLatencyResult:
     """
     Scan every partition for a single consumer group on one dedicated consumer.
     """
     scans: list[TopicConsumerLatency] = []
     errors: list[Exception] = []
+
+    if stop_event is not None and stop_event.is_set():
+        return ConsumerLatencyResult(scans=scans, errors=errors)
 
     committed = get_committed_offsets(admin, [group_id])[group_id]
     if isinstance(committed, Exception):
@@ -236,7 +244,9 @@ def get_consumer_group_latency(
 
     consumer = Consumer(dict(consumer_config))
     try:
-        latencies, scan_errors = scan_partition_latencies(consumer, group_scans, timeout)
+        latencies, scan_errors = scan_partition_latencies(
+            consumer, group_scans, timeout, stop_event
+        )
         errors.extend(scan_errors)
         for item in group_scans:
             latency_ms = latencies.get((item.topic, item.partition))
@@ -266,6 +276,7 @@ def get_cluster_latency(
     topics: Mapping[str, TopicConfig],
     timeout: int,
     max_workers: int = DEFAULT_MAX_WORKERS,
+    stop_event: threading.Event | None = None,
 ) -> ConsumerLatencyResult:
     consumer_group_id = f"consumer-latency-group-{cluster_name}"
     scans: list[TopicConsumerLatency] = []
@@ -320,16 +331,24 @@ def get_cluster_latency(
                     group_id,
                     retentions_by_topic,
                     timeout,
+                    stop_event,
                 )
                 for group_id in scan_group_ids
             ]
-            for future in as_completed(futures):
-                try:
-                    group_result = future.result()
-                    scans.extend(group_result.scans)
-                    errors.extend(group_result.errors)
-                except Exception as e:
-                    errors.append(e)
+            try:
+                for future in as_completed(futures):
+                    if stop_event is not None and stop_event.is_set():
+                        break
+                    try:
+                        group_result = future.result()
+                        scans.extend(group_result.scans)
+                        errors.extend(group_result.errors)
+                    except Exception as e:
+                        errors.append(e)
+            finally:
+                if stop_event is not None and stop_event.is_set():
+                    for future in futures:
+                        future.cancel()
     except Exception as e:
         errors.append(e)
 
@@ -343,15 +362,20 @@ def record_consumer_group_latency(
     metrics: MetricsBackend,
     timeout: int = 10,
     max_workers: int = DEFAULT_MAX_WORKERS,
+    stop_event: threading.Event | None = None,
 ) -> ConsumerLatencyResult:
     scans: list[TopicConsumerLatency] = []
     errors: list[Exception] = []
     clusters = config.get_clusters()
 
     for cluster_name, cluster_config in clusters.items():
+        if stop_event is not None and stop_event.is_set():
+            break
         try:
             topics = config.get_topics_config(cluster_name)
-            result = get_cluster_latency(cluster_name, cluster_config, topics, timeout, max_workers)
+            result = get_cluster_latency(
+                cluster_name, cluster_config, topics, timeout, max_workers, stop_event
+            )
         except Exception as e:
             errors.append(e)
             continue

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -365,6 +365,16 @@ def record_consumer_group_latency(
     stop_event: threading.Event | None = None,
     clusters: tuple[str, ...] | None = None,
 ) -> ConsumerLatencyResult:
+    """Collect and emit consumer latency for each selected cluster.
+
+    Args:
+        config: Kafka configuration providing the clusters and their topics.
+        metrics: Backend that per-partition latency histograms are emitted to.
+        timeout: Seconds to wait for each Kafka request before timing out.
+        max_workers: Maximum concurrent partition scans per cluster.
+        stop_event: Optional shutdown signal; when set, scanning stops early.
+        clusters: Names of clusters to scan; defaults to all when empty or None.
+    """
     scans: list[TopicConsumerLatency] = []
     errors: list[Exception] = []
 

--- a/sentry_kafka_management/actions/latency/consumer_latency.py
+++ b/sentry_kafka_management/actions/latency/consumer_latency.py
@@ -5,7 +5,7 @@ import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
-from typing import Mapping
+from typing import Collection, Mapping
 
 from confluent_kafka import (  # type: ignore[import-untyped]
     TIMESTAMP_NOT_AVAILABLE,
@@ -363,12 +363,19 @@ def record_consumer_group_latency(
     timeout: int = 10,
     max_workers: int = DEFAULT_MAX_WORKERS,
     stop_event: threading.Event | None = None,
+    clusters: Collection[str] | None = None,
 ) -> ConsumerLatencyResult:
     scans: list[TopicConsumerLatency] = []
     errors: list[Exception] = []
-    clusters = config.get_clusters()
 
-    for cluster_name, cluster_config in clusters.items():
+    available_clusters = config.get_clusters()
+    if clusters:
+        selected = set(clusters)
+        cluster_items = {name: cfg for name, cfg in available_clusters.items() if name in selected}
+    else:
+        cluster_items = dict(available_clusters)
+
+    for cluster_name, cluster_config in cluster_items.items():
         if stop_event is not None and stop_event.is_set():
             break
         try:

--- a/sentry_kafka_management/scripts/latency/consumer_latency.py
+++ b/sentry_kafka_management/scripts/latency/consumer_latency.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 import logging
-import time
+import signal
+import threading
+import types
 from pathlib import Path
 
 import click
@@ -88,15 +90,24 @@ def consumer_latency(
     kafka_config = YamlKafkaConfig(config)
     metrics_backend = DatadogMetricsBackend(statsd_host, statsd_port)
 
+    stop_event = threading.Event()
+
+    def handle_signal(signum: int, _frame: types.FrameType | None) -> None:
+        click.echo(f"Received {signal.Signals(signum).name}, shutting down.")
+        stop_event.set()
+
+    signal.signal(signal.SIGINT, handle_signal)
+    signal.signal(signal.SIGTERM, handle_signal)
+
     click.echo(
         f"Starting consumer latency collection "
         f"(interval={interval:.3f}s, max_workers={max_workers})"
     )
 
-    while True:
+    while not stop_event.is_set():
         try:
             result = record_consumer_group_latency_action(
-                kafka_config, metrics_backend, timeout, max_workers
+                kafka_config, metrics_backend, timeout, max_workers, stop_event
             )
         except Exception:
             sentry_sdk.capture_exception()
@@ -120,4 +131,6 @@ def consumer_latency(
                 f"Consumer latency collection failed ({len(result.errors)} error(s))"
             )
 
-        time.sleep(interval)
+        stop_event.wait(interval)
+
+    click.echo("Consumer latency collection stopped")

--- a/sentry_kafka_management/scripts/latency/consumer_latency.py
+++ b/sentry_kafka_management/scripts/latency/consumer_latency.py
@@ -63,6 +63,14 @@ from sentry_kafka_management.brokers import YamlKafkaConfig
     help="Maximum concurrent partition scans per cluster. Defaults to 128.",
 )
 @click.option(
+    "-k",
+    "--cluster",
+    "clusters",
+    required=False,
+    multiple=True,
+    help="Cluster name to scan. Repeatable. Defaults to all clusters in the config.",
+)
+@click.option(
     "-l",
     "--log-level",
     required=False,
@@ -77,6 +85,7 @@ def consumer_latency(
     interval: float,
     timeout: int,
     max_workers: int,
+    clusters: tuple[str, ...],
     log_level: str,
 ) -> None:
     """
@@ -90,6 +99,15 @@ def consumer_latency(
     kafka_config = YamlKafkaConfig(config)
     metrics_backend = DatadogMetricsBackend(statsd_host, statsd_port)
 
+    available_clusters = set(kafka_config.get_clusters())
+    unknown_clusters = set(clusters) - available_clusters
+    if unknown_clusters:
+        raise click.BadParameter(
+            f"Unknown cluster(s): {', '.join(sorted(unknown_clusters))}. "
+            f"Available clusters: {', '.join(sorted(available_clusters))}",
+            param_hint="--cluster",
+        )
+
     stop_event = threading.Event()
 
     def handle_signal(signum: int, _frame: types.FrameType | None) -> None:
@@ -99,15 +117,21 @@ def consumer_latency(
     signal.signal(signal.SIGINT, handle_signal)
     signal.signal(signal.SIGTERM, handle_signal)
 
+    clusters_desc = ", ".join(clusters) if clusters else "all"
     click.echo(
         f"Starting consumer latency collection "
-        f"(interval={interval:.3f}s, max_workers={max_workers})"
+        f"(interval={interval:.3f}s, max_workers={max_workers}, clusters={clusters_desc})"
     )
 
     while not stop_event.is_set():
         try:
             result = record_consumer_group_latency_action(
-                kafka_config, metrics_backend, timeout, max_workers, stop_event
+                kafka_config,
+                metrics_backend,
+                timeout,
+                max_workers,
+                stop_event,
+                clusters=clusters,
             )
         except Exception:
             sentry_sdk.capture_exception()

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import threading
 from concurrent.futures import Future
 from unittest.mock import MagicMock, Mock, patch
 
@@ -369,6 +370,50 @@ def test_scan_partition_latencies_records_timeout_for_unread_partitions() -> Non
     assert latencies == {}
     assert len(errors) == 1
     assert isinstance(errors[0], TimeoutError)
+
+
+def test_scan_partition_latencies_returns_early_when_stopped() -> None:
+    consumer = Mock()
+    consumer.poll.return_value = None
+    stop_event = threading.Event()
+    stop_event.set()
+
+    latencies, errors = scan_partition_latencies(
+        consumer, [_scan()], timeout=10, stop_event=stop_event
+    )
+
+    assert latencies == {}
+    assert errors == []
+    consumer.poll.assert_not_called()
+
+
+@patch("sentry_kafka_management.actions.latency.consumer_latency.get_cluster_latency")
+def test_record_consumer_group_latency_stops_between_clusters(
+    mock_get_cluster_latency: MagicMock,
+) -> None:
+    config = Mock()
+    config.get_clusters.return_value = {
+        "cluster1": CLUSTER_CONFIG,
+        "cluster2": CLUSTER_CONFIG,
+    }
+    config.get_topics_config.return_value = {"topic-a": {}}
+    stop_event = threading.Event()
+
+    def stop_after_first(
+        cluster_name: str, *_args: object, **_kwargs: object
+    ) -> ConsumerLatencyResult:
+        stop_event.set()
+        return ConsumerLatencyResult(
+            scans=[TopicConsumerLatency(cluster_name, "topic-a", "group-a", 1.0, partition=0)],
+        )
+
+    mock_get_cluster_latency.side_effect = stop_after_first
+    metrics = FakeMetricsBackend()
+
+    result = record_consumer_group_latency(config, metrics, stop_event=stop_event)
+
+    assert mock_get_cluster_latency.call_count == 1
+    assert len(result.scans) == 1
 
 
 @patch("sentry_kafka_management.actions.latency.consumer_latency.Consumer")

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -911,6 +911,47 @@ def test_record_consumer_group_latency_emits_one_histogram_per_scan(
 
 
 @patch("sentry_kafka_management.actions.latency.consumer_latency.get_cluster_latency")
+def test_record_consumer_group_latency_scans_only_selected_clusters(
+    mock_get_cluster_latency: MagicMock,
+) -> None:
+    config = Mock()
+    config.get_clusters.return_value = {
+        "cluster1": CLUSTER_CONFIG,
+        "cluster2": CLUSTER_CONFIG,
+    }
+    config.get_topics_config.return_value = {"topic-a": {}}
+    mock_get_cluster_latency.side_effect = lambda name, *a, **k: ConsumerLatencyResult(
+        scans=[TopicConsumerLatency(name, "topic-a", "group-a", 1.0, partition=0)],
+    )
+    metrics = FakeMetricsBackend()
+
+    result = record_consumer_group_latency(config, metrics, clusters=["cluster2"])
+
+    scanned = [call.args[0] for call in mock_get_cluster_latency.call_args_list]
+    assert scanned == ["cluster2"]
+    assert [scan.cluster_name for scan in result.scans] == ["cluster2"]
+
+
+@patch("sentry_kafka_management.actions.latency.consumer_latency.get_cluster_latency")
+def test_record_consumer_group_latency_scans_all_clusters_by_default(
+    mock_get_cluster_latency: MagicMock,
+) -> None:
+    config = Mock()
+    config.get_clusters.return_value = {
+        "cluster1": CLUSTER_CONFIG,
+        "cluster2": CLUSTER_CONFIG,
+    }
+    config.get_topics_config.return_value = {"topic-a": {}}
+    mock_get_cluster_latency.return_value = ConsumerLatencyResult(scans=[])
+    metrics = FakeMetricsBackend()
+
+    record_consumer_group_latency(config, metrics)
+
+    scanned = {call.args[0] for call in mock_get_cluster_latency.call_args_list}
+    assert scanned == {"cluster1", "cluster2"}
+
+
+@patch("sentry_kafka_management.actions.latency.consumer_latency.get_cluster_latency")
 def test_record_consumer_group_latency_emits_nothing_when_no_clusters_have_latency(
     mock_get_cluster_latency: MagicMock,
 ) -> None:

--- a/tests/actions/latency/test_consumer_latency.py
+++ b/tests/actions/latency/test_consumer_latency.py
@@ -925,7 +925,7 @@ def test_record_consumer_group_latency_scans_only_selected_clusters(
     )
     metrics = FakeMetricsBackend()
 
-    result = record_consumer_group_latency(config, metrics, clusters=["cluster2"])
+    result = record_consumer_group_latency(config, metrics, clusters=("cluster2",))
 
     scanned = [call.args[0] for call in mock_get_cluster_latency.call_args_list]
     assert scanned == ["cluster2"]

--- a/tests/scripts/test_latency.py
+++ b/tests/scripts/test_latency.py
@@ -1,4 +1,7 @@
+import signal
+import threading
 from pathlib import Path
+from typing import Callable
 from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner, Result
@@ -19,11 +22,28 @@ def test_consumer_latency_requires_statsd_options(temp_config: Path) -> None:
     assert "statsd-host" in result.output
 
 
+def _stop_after(iterations: int) -> Callable[..., bool]:
+    """Build a ``threading.Event.wait`` side effect that stops after N waits.
+
+    Mirrors how a SIGINT/SIGTERM handler sets the shutdown event: the loop's
+    interruptible sleep returns and the process exits cleanly.
+    """
+
+    def wait_side_effect(self: threading.Event, _timeout: float | None = None) -> bool:
+        if wait_side_effect.calls >= iterations:  # type: ignore[attr-defined]
+            self.set()
+        wait_side_effect.calls += 1  # type: ignore[attr-defined]
+        return self.is_set()
+
+    wait_side_effect.calls = 1  # type: ignore[attr-defined]
+    return wait_side_effect
+
+
 @patch("sentry_kafka_management.scripts.latency.consumer_latency.DatadogMetricsBackend")
 @patch("sentry_kafka_management.actions.latency.consumer_latency.get_cluster_latency")
-@patch("time.sleep")
+@patch.object(threading.Event, "wait", autospec=True)
 def test_consumer_latency_runs_collection_loop_and_emits_metrics(
-    mock_sleep: MagicMock,
+    mock_wait: MagicMock,
     mock_get_cluster_latency: MagicMock,
     mock_metrics_backend_cls: MagicMock,
     temp_config: Path,
@@ -43,15 +63,15 @@ def test_consumer_latency_runs_collection_loop_and_emits_metrics(
         )
     )
 
-    mock_sleep.side_effect = [None, KeyboardInterrupt]
+    mock_wait.side_effect = _stop_after(2)
 
     result = runner_invoke_with_statsd(temp_config, interval="0.25")
 
-    assert result.exit_code != 0
+    assert result.exit_code == 0
 
     mock_metrics_backend_cls.assert_called_once_with("localhost", 8126)
-    mock_sleep.assert_called_with(0.25)
-    assert mock_sleep.call_count == 2
+    assert mock_wait.call_args.args[1] == 0.25
+    assert mock_wait.call_count == 2
 
     assert mock_get_cluster_latency.call_count == 4
     called_clusters = {call.args[0] for call in mock_get_cluster_latency.call_args_list}
@@ -63,15 +83,15 @@ def test_consumer_latency_runs_collection_loop_and_emits_metrics(
 @patch(
     "sentry_kafka_management.scripts.latency.consumer_latency.record_consumer_group_latency_action"
 )
-@patch("time.sleep")
+@patch.object(threading.Event, "wait", autospec=True)
 def test_consumer_latency_passes_max_workers(
-    mock_sleep: MagicMock,
+    mock_wait: MagicMock,
     mock_record: MagicMock,
     mock_metrics_backend_cls: MagicMock,
     temp_config: Path,
 ) -> None:
     mock_record.return_value = ConsumerLatencyResult(scans=[])
-    mock_sleep.side_effect = KeyboardInterrupt
+    mock_wait.side_effect = _stop_after(1)
 
     result = CliRunner().invoke(
         consumer_latency,
@@ -87,29 +107,61 @@ def test_consumer_latency_passes_max_workers(
         ],
     )
 
-    assert result.exit_code != 0
+    assert result.exit_code == 0
     mock_record.assert_called_once()
     assert mock_record.call_args.args[3] == 32
 
 
 @patch("sentry_kafka_management.scripts.latency.consumer_latency.DatadogMetricsBackend")
 @patch("sentry_kafka_management.actions.latency.consumer_latency.get_cluster_latency")
-@patch("time.sleep")
+@patch.object(threading.Event, "wait", autospec=True)
 def test_consumer_latency_handles_iterations_with_no_scans(
-    mock_sleep: MagicMock,
+    mock_wait: MagicMock,
     mock_get_cluster_latency: MagicMock,
     mock_metrics_backend_cls: MagicMock,
     temp_config: Path,
 ) -> None:
     metrics_backend = mock_metrics_backend_cls.return_value
     mock_get_cluster_latency.return_value = ConsumerLatencyResult(scans=[])
-    mock_sleep.side_effect = KeyboardInterrupt
+    mock_wait.side_effect = _stop_after(1)
 
     result = runner_invoke_with_statsd(temp_config)
 
-    assert result.exit_code != 0
+    assert result.exit_code == 0
     assert "No consumer latency collected" in result.output
     metrics_backend.histogram.assert_not_called()
+
+
+@patch("sentry_kafka_management.scripts.latency.consumer_latency.DatadogMetricsBackend")
+@patch(
+    "sentry_kafka_management.scripts.latency.consumer_latency.record_consumer_group_latency_action"
+)
+@patch("signal.signal")
+def test_consumer_latency_stops_gracefully_on_signal(
+    mock_signal: MagicMock,
+    mock_record: MagicMock,
+    mock_metrics_backend_cls: MagicMock,
+    temp_config: Path,
+) -> None:
+    handlers: dict[int, Callable[[int, object], None]] = {}
+    mock_signal.side_effect = lambda signum, handler: handlers.__setitem__(signum, handler)
+
+    def record_then_signal(*_args: object, **_kwargs: object) -> ConsumerLatencyResult:
+        # Simulate SIGTERM (e.g. a Kubernetes pod stop) landing mid-loop.
+        handlers[signal.SIGTERM](signal.SIGTERM, None)
+        return ConsumerLatencyResult(scans=[])
+
+    mock_record.side_effect = record_then_signal
+
+    result = runner_invoke_with_statsd(temp_config)
+
+    assert result.exit_code == 0
+    assert signal.SIGINT in handlers and signal.SIGTERM in handlers
+    mock_record.assert_called_once()
+    stop_event = mock_record.call_args.args[4]
+    assert stop_event.is_set()
+    assert "shutting down" in result.output
+    assert "stopped" in result.output
 
 
 def runner_invoke_with_statsd(temp_config: Path, interval: str | None = None) -> Result:

--- a/tests/scripts/test_latency.py
+++ b/tests/scripts/test_latency.py
@@ -164,6 +164,67 @@ def test_consumer_latency_stops_gracefully_on_signal(
     assert "stopped" in result.output
 
 
+@patch("sentry_kafka_management.scripts.latency.consumer_latency.DatadogMetricsBackend")
+@patch(
+    "sentry_kafka_management.scripts.latency.consumer_latency.record_consumer_group_latency_action"
+)
+@patch.object(threading.Event, "wait", autospec=True)
+def test_consumer_latency_passes_selected_clusters(
+    mock_wait: MagicMock,
+    mock_record: MagicMock,
+    mock_metrics_backend_cls: MagicMock,
+    temp_config: Path,
+) -> None:
+    mock_record.return_value = ConsumerLatencyResult(scans=[])
+    mock_wait.side_effect = _stop_after(1)
+
+    result = CliRunner().invoke(
+        consumer_latency,
+        [
+            "--config",
+            str(temp_config),
+            "--statsd-host",
+            "localhost",
+            "--statsd-port",
+            "8126",
+            "--cluster",
+            "cluster2",
+        ],
+    )
+
+    assert result.exit_code == 0
+    mock_record.assert_called_once()
+    assert mock_record.call_args.kwargs["clusters"] == ("cluster2",)
+
+
+@patch("sentry_kafka_management.scripts.latency.consumer_latency.DatadogMetricsBackend")
+@patch(
+    "sentry_kafka_management.scripts.latency.consumer_latency.record_consumer_group_latency_action"
+)
+def test_consumer_latency_rejects_unknown_cluster(
+    mock_record: MagicMock,
+    mock_metrics_backend_cls: MagicMock,
+    temp_config: Path,
+) -> None:
+    result = CliRunner().invoke(
+        consumer_latency,
+        [
+            "--config",
+            str(temp_config),
+            "--statsd-host",
+            "localhost",
+            "--statsd-port",
+            "8126",
+            "--cluster",
+            "does-not-exist",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Unknown cluster(s): does-not-exist" in result.output
+    mock_record.assert_not_called()
+
+
 def runner_invoke_with_statsd(temp_config: Path, interval: str | None = None) -> Result:
     args = [
         "--config",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import json
+import threading
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -63,15 +64,20 @@ def test_cli_brokers_describe_configs(
 @patch(
     "sentry_kafka_management.scripts.latency.consumer_latency.record_consumer_group_latency_action"
 )
-@patch("time.sleep")
+@patch.object(threading.Event, "wait", autospec=True)
 def test_cli_consumer_latency(
-    mock_sleep: MagicMock,
+    mock_wait: MagicMock,
     mock_record_consumer_group_latency: MagicMock,
     mock_metrics_backend: MagicMock,
     temp_config: Path,
 ) -> None:
     mock_record_consumer_group_latency.return_value = ConsumerLatencyResult(scans=[])
-    mock_sleep.side_effect = KeyboardInterrupt
+
+    def stop_loop(event: threading.Event, _timeout: float | None = None) -> bool:
+        event.set()
+        return True
+
+    mock_wait.side_effect = stop_loop
 
     runner = click.testing.CliRunner()
     result = runner.invoke(
@@ -87,6 +93,6 @@ def test_cli_consumer_latency(
         ],
     )
 
-    assert result.exit_code != 0
+    assert result.exit_code == 0
     mock_metrics_backend.assert_called_once_with("localhost", 8125)
     mock_record_consumer_group_latency.assert_called_once()


### PR DESCRIPTION
Makes the process return a proper exit code when getting shut down by an interrupt (SIGINT/SIGTERM). Potentially identified as a problem when k8s tries to restart a deployment and the old shutdown isn't clean.

Also adds ability to specify clusters to scan (defaults to all) so we can slowly add more clusters when we roll out to DE/US and make sure we aren't overloaded.