### PR TITLE
feat(topics): add static assignment follower balancing

### DIFF
--- a/sentry_kafka_management/actions/topics/placement.py
+++ b/sentry_kafka_management/actions/topics/placement.py
@@ -91,6 +91,45 @@ def _build_slice_assignment(broker_slice: Slice, assignment_idx: int) -> Assignm
     return assignment
 
 
+def _flip_assignment_followers(assignment: Assignment) -> Assignment:
+    if len(assignment) != SLICE_SIZE:
+        raise ValueError(f"Expected {SLICE_SIZE} replicas, got {len(assignment)}")
+    return [assignment[0], *reversed(assignment[1:])]
+
+
+def balance_assignment_followers(
+    topic_placements: list[TopicPlacement],
+) -> list[TopicPlacement]:
+    """
+    Balance failover leaders without changing preferred leaders or replica sets.
+
+    For assignments with the same leader and follower set, preserve the first occurrence's
+    follower order and alternate every subsequent occurrence between the two possible orders.
+    """
+    assignment_groups: dict[tuple[BrokerId, tuple[BrokerId, ...]], Assignment] = {}
+    flip_next: defaultdict[tuple[BrokerId, tuple[BrokerId, ...]], bool] = defaultdict(bool)
+    balanced_placements: list[TopicPlacement] = []
+    for topic_placement in topic_placements:
+        balanced_assignments: list[Assignment] = []
+        for assignment in topic_placement.partitions:
+            if len(assignment) != SLICE_SIZE:
+                raise ValueError(f"Expected {SLICE_SIZE} replicas, got {len(assignment)}")
+
+            assignment_group = (
+                assignment[0],
+                tuple(sorted(assignment[1:])),
+            )
+            base_assignment = assignment_groups.setdefault(assignment_group, assignment.copy())
+            if flip_next[assignment_group]:
+                balanced_assignments.append(_flip_assignment_followers(base_assignment))
+            else:
+                balanced_assignments.append(base_assignment.copy())
+            flip_next[assignment_group] = not flip_next[assignment_group]
+        balanced_placements.append(TopicPlacement(topic_placement.topic, balanced_assignments))
+
+    return balanced_placements
+
+
 def compute_cluster_placement(
     broker_id_mapping: dict[str, BrokerId],
     topic_partitions: dict[str, int],

--- a/sentry_kafka_management/cli.py
+++ b/sentry_kafka_management/cli.py
@@ -31,10 +31,14 @@ from sentry_kafka_management.scripts.topics.healthcheck import (
     healthcheck_cluster_topics,
 )
 from sentry_kafka_management.scripts.topics.partitions import elect_partition_leaders
-from sentry_kafka_management.scripts.topics.placement import compute_topic_placement
+from sentry_kafka_management.scripts.topics.placement import (
+    balance_topic_assignment_followers,
+    compute_topic_placement,
+)
 
 COMMANDS = [
     apply_configs,
+    balance_topic_assignment_followers,
     compute_topic_placement,
     consumer_latency,
     describe_topic_partitions,

--- a/sentry_kafka_management/scripts/topics/placement.py
+++ b/sentry_kafka_management/scripts/topics/placement.py
@@ -9,6 +9,7 @@ import yaml
 from sentry_kafka_management.actions.brokers.parser import BrokerId, get_broker_id
 from sentry_kafka_management.actions.topics.placement import (
     TopicPlacement,
+    balance_assignment_followers,
     compute_cluster_placement,
 )
 
@@ -66,6 +67,34 @@ def parse_topic_partitions(
     return topic_partitions
 
 
+def parse_static_topic_placements(
+    shared_config_path: Path, region: str, cluster_name: str
+) -> list[TopicPlacement]:
+    """Read existing static assignments for every topic in a cluster."""
+    overrides_directory = shared_config_path / "topics" / "regional_overrides" / region
+    topic_placements: list[TopicPlacement] = []
+
+    for topic_file in sorted(overrides_directory.glob("*.yaml")):
+        with open(topic_file, "r") as f:
+            config = yaml.safe_load(f) or {}
+
+        if config.get("cluster") != cluster_name:
+            continue
+
+        static_assignments = config.get("placement", {}).get("staticAssignments")
+        if static_assignments is None:
+            continue
+
+        topic_placements.append(
+            TopicPlacement(
+                topic_file.stem,
+                [list(assignment) for assignment in static_assignments],
+            )
+        )
+
+    return topic_placements
+
+
 def count_leader_distribution(result: list[TopicPlacement]) -> None:
     """Print how many partition leaders and total replicas each broker holds."""
     leader_counts: dict[BrokerId, int] = defaultdict(int)
@@ -80,6 +109,49 @@ def count_leader_distribution(result: list[TopicPlacement]) -> None:
     sorted_replicas = [str(replica_counts[b]) for b in sorted(replica_counts)]
     click.echo(f"Leader distribution: {'/'.join(sorted_leaders)}")
     click.echo(f"Replica distribution: {'/'.join(sorted_replicas)}")
+
+
+@click.command()
+@click.option("--shared-config-path", type=click.Path(exists=True, path_type=Path), required=True)
+@click.option("--region", required=True)
+@click.option("--cluster-name", required=True)
+def balance_topic_assignment_followers(
+    shared_config_path: Path,
+    region: str,
+    cluster_name: str,
+) -> None:
+    """Balance follower order in existing static assignments without moving replicas."""
+    topic_placements = parse_static_topic_placements(shared_config_path, region, cluster_name)
+    balanced_placements = balance_assignment_followers(topic_placements)
+    overrides_directory = shared_config_path / "topics" / "regional_overrides" / region
+
+    flipped_assignments = 0
+    changed_topics = 0
+    for original, balanced in zip(topic_placements, balanced_placements, strict=True):
+        topic_flips = sum(
+            original_assignment != balanced_assignment
+            for original_assignment, balanced_assignment in zip(
+                original.partitions, balanced.partitions, strict=True
+            )
+        )
+        if topic_flips == 0:
+            continue
+
+        file_path = overrides_directory / f"{balanced.topic}.yaml"
+        with open(file_path, "r") as f:
+            config = yaml.safe_load(f) or {}
+
+        config["placement"]["staticAssignments"] = balanced.partitions
+
+        with open(file_path, "w") as f:
+            yaml.dump(config, f, default_flow_style=None)
+        click.echo(f"Wrote {file_path}")
+
+        flipped_assignments += topic_flips
+        changed_topics += 1
+
+    topic_label = "topic" if changed_topics == 1 else "topics"
+    click.echo(f"Flipped {flipped_assignments} assignments across {changed_topics} {topic_label}")
 
 
 @click.command()

--- a/tests/actions/topics/test_placement.py
+++ b/tests/actions/topics/test_placement.py
@@ -5,6 +5,8 @@ import pytest
 from sentry_kafka_management.actions.brokers.parser import BrokerId
 from sentry_kafka_management.actions.topics.placement import (
     SLICE_SIZE,
+    TopicPlacement,
+    balance_assignment_followers,
     build_slices,
     compute_cluster_placement,
 )
@@ -261,3 +263,66 @@ def test_failover_leadership_is_evenly_distributed() -> None:
         1: Counter({0: 1, 2: 1}),
         2: Counter({0: 1, 1: 1}),
     }
+
+
+def test_balances_existing_assignment_followers_without_moving_replicas() -> None:
+    original = [
+        TopicPlacement(
+            "topic-a",
+            [
+                [0, 1, 2],
+                [0, 1, 2],
+                [1, 2, 0],
+                [0, 1, 2],
+            ],
+        ),
+        TopicPlacement(
+            "topic-b",
+            [
+                [0, 1, 2],
+                [1, 2, 0],
+                [0, 1, 2],
+            ],
+        ),
+    ]
+
+    balanced = balance_assignment_followers(original)
+
+    assert balanced == [
+        TopicPlacement(
+            "topic-a",
+            [
+                [0, 1, 2],
+                [0, 2, 1],
+                [1, 2, 0],
+                [0, 1, 2],
+            ],
+        ),
+        TopicPlacement(
+            "topic-b",
+            [
+                [0, 2, 1],
+                [1, 0, 2],
+                [0, 1, 2],
+            ],
+        ),
+    ]
+
+    assignment_counts = Counter(
+        tuple(assignment)
+        for topic_placement in balanced
+        for assignment in topic_placement.partitions
+    )
+    assert assignment_counts[(0, 1, 2)] == 3
+    assert assignment_counts[(0, 2, 1)] == 2
+    assert assignment_counts[(1, 2, 0)] == 1
+    assert assignment_counts[(1, 0, 2)] == 1
+
+    for original_topic, balanced_topic in zip(original, balanced, strict=True):
+        for original_assignment, balanced_assignment in zip(
+            original_topic.partitions, balanced_topic.partitions, strict=True
+        ):
+            assert balanced_assignment[0] == original_assignment[0]
+            assert set(balanced_assignment) == set(original_assignment)
+
+    assert balance_assignment_followers(balanced) == balanced

--- a/tests/scripts/topics/test_placement.py
+++ b/tests/scripts/topics/test_placement.py
@@ -1,13 +1,17 @@
+from collections import Counter
 from pathlib import Path
 
 import pytest
 import yaml
+from click.testing import CliRunner
 
 from sentry_kafka_management.actions.topics.placement import TopicPlacement
 from sentry_kafka_management.scripts.topics.placement import (
+    balance_topic_assignment_followers,
     count_leader_distribution,
     get_default_partitions,
     get_topic_partitions,
+    parse_static_topic_placements,
     parse_topic_partitions,
 )
 
@@ -105,3 +109,53 @@ def test_count_leader_distribution(capsys: pytest.CaptureFixture[str]) -> None:
     output = capsys.readouterr().out
     assert "Leader distribution: 3/2" in output
     assert "Replica distribution: 3/3/3/2/2/2" in output
+
+
+def test_parse_static_topic_placements(shared_config: Path) -> None:
+    topic_path = shared_config / "topics" / "regional_overrides" / "region-1" / "topic-a.yaml"
+    config = yaml.safe_load(topic_path.read_text())
+    config["placement"] = {
+        "staticAssignments": [[0, 1, 2], [0, 1, 2]],
+        "strategy": "static",
+    }
+    topic_path.write_text(yaml.dump(config))
+
+    result = parse_static_topic_placements(shared_config, "region-1", "cluster-1")
+
+    assert result == [TopicPlacement("topic-a", [[0, 1, 2], [0, 1, 2]])]
+
+
+def test_balance_topic_assignment_followers_command(shared_config: Path) -> None:
+    overrides_directory = shared_config / "topics" / "regional_overrides" / "region-1"
+    for topic_name in ("topic-a", "topic-b"):
+        topic_path = overrides_directory / f"{topic_name}.yaml"
+        config = yaml.safe_load(topic_path.read_text())
+        config["placement"] = {
+            "staticAssignments": [[0, 1, 2], [0, 1, 2]],
+            "strategy": "static",
+        }
+        topic_path.write_text(yaml.dump(config))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        balance_topic_assignment_followers,
+        [
+            "--shared-config-path",
+            str(shared_config),
+            "--region",
+            "region-1",
+            "--cluster-name",
+            "cluster-1",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "Flipped 2 assignments across 2 topics" in result.output
+
+    assignment_counts: Counter[tuple[int, ...]] = Counter()
+    for topic_name in ("topic-a", "topic-b"):
+        config = yaml.safe_load((overrides_directory / f"{topic_name}.yaml").read_text())
+        assignment_counts.update(
+            tuple(assignment) for assignment in config["placement"]["staticAssignments"]
+        )
+    assert assignment_counts == Counter({(0, 2, 1): 2, (0, 1, 2): 2})


### PR DESCRIPTION
Refs STREAM-1614

Add a `balance-topic-assignment-followers` command that balances failover leadership using existing static assignments.

Unlike `compute-topic-placement`, this command does not recompute partition placement. It only changes follower ordering.

## Problem

Existing assignments place the same follower immediately after a preferred leader. When that leader becomes unavailable, failover leadership is concentrated on one broker. Recomputing placement fixes this but can also shift topics leaders because the placement algorithm depends on sorted topic order.

## Solution

The new command:

- Reads existing `staticAssignments` for the selected region and cluster.
- Groups assignments with the same preferred leader and follower set.
- Alternates subsequent occurrences between the two follower orders.
- Leaves assignments that already follow the alternating sequence unchanged.